### PR TITLE
FUZZ-4577: Reduce default queueSize and add cli option to make it configurable

### DIFF
--- a/src/main/groovy/com/ciq/fuzzball/FuzzballExecutor.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballExecutor.groovy
@@ -109,11 +109,12 @@ class FuzzballExecutor extends Executor implements ExtensionPoint {
     }
 
     /**
-     * @return Create a new instance of the {@code TaskQueueHolder} component
+     * Using a low default queueSize of 20. Can be overridden by the user with the queueSize executor config option.
+     * @return Create a new instance of the {@code TaskQueueHolder} component.
      */
     @Override
     protected TaskMonitor createTaskMonitor() {
-        return TaskPollingMonitor.create(session, name, 1000, Duration.of('20 sec'))
+        return TaskPollingMonitor.create(session, name, 20, Duration.of('20 sec'))
     }
 
     /**

--- a/submit/submit_nextflow.py
+++ b/submit/submit_nextflow.py
@@ -367,6 +367,11 @@ class MinimalFuzzballClient:
         plugins {{ id 'nf-fuzzball@{plugin_version}' }}
         profiles {{
             fuzzball {{
+                executor {{
+                    '$fuzzball' {{
+                        queueSize = {args.queue_size}
+                    }}
+                }}
                 process {{
                     executor = 'fuzzball'
                 }}
@@ -571,6 +576,15 @@ def parse_cli() -> argparse.Namespace:
         "--nf-core",
         action="store_true",
         help="Use nf-core conventions",
+    )
+    parser.add_argument(
+        "--queue-size",
+        type=int,
+        default=20,
+        help=(
+            "Queue size for the Fuzzball executor. This is the number of jobs that can be queued at once. "
+            "[%(default)s]"
+        ),
     )
     parser.add_argument(
         "--s3-secret",


### PR DESCRIPTION
The large default queue size ended up exceeding our AWS vCPU limits causing lots of problems on the stable cluster. It eventually recovered but this should still be (a) configurable and (b) use a small default to force users to explicitly choose a larger default if they need it.

This required minimal change since the polling queue monitor already implements a limit and a matching configuration setting so we essentially get it for free.