### PR TITLE
Retry failed submissions

### DIFF
--- a/submit/submit_nextflow.py
+++ b/submit/submit_nextflow.py
@@ -392,6 +392,7 @@ class MinimalFuzzballClient:
                 executor {{
                     '$fuzzball' {{
                         queueSize = {args.queue_size}
+                        retry {{ maxAttempt = 3 }}
                     }}
                 }}
                 process {{


### PR DESCRIPTION
This will make nextflow retry a failed submission. This should prevent interrupted pipelines due to submissions failing when AWS instances are not available.