### PR TITLE
FUZZ-4712: self signed certificates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - '*'
-  push: 
+  push:
     tags:
       - "v*.*.*"
   workflow_dispatch:
@@ -23,49 +23,42 @@ jobs:
 
     steps:
 
-      - name: Get Fuzzball version on stable
+      - name: Get Fuzzball version on stable (starts with 'v')
         run: |
           FUZZBALL_VERSION=$(curl -s https://api.stable.fuzzball.ciq.dev/v2/version | jq -r '.version')
-          echo "FUZZBALL_VERSION=${FUZZBALL_VERSION}" >> $GITHUB_ENV
+          # make sure Fuzzball version starts with a v
+          echo "FUZZBALL_VERSION=v${FUZZBALL_VERSION#v}" >> $GITHUB_ENV
 
       - name: Environment
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: true
-      
-      - name: Set plugin version
-        run: |
 
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            echo "Using tag as plugin version"
-            PLUGIN_VERSION="${{ github.ref_name }}"
-            # Remove the v prefix if it exists
-            echo "PLUGIN_VERSION=${PLUGIN_VERSION#v}" >> $GITHUB_ENV
-          else
-            echo "Not pushing to a tag, using build.gradle to determine plugin version"
-            PLUGIN_VERSION=$(grep -E "version\s*=" build.gradle | head -1 | sed -E "s/.*version\s*=\s*'([^']+)'.*/\1/")
-            echo "PLUGIN_VERSION=${PLUGIN_VERSION}" >> $GITHUB_ENV
-          fi
+      - name: Set plugin version (starts with 'v')
+        run: |
+          # PLUGIN_VERSION always comes from gradle but we make sure it also starts with a v
+          PLUGIN_VERSION=$(grep -E "version\s*=" build.gradle | head -1 | sed -E "s/.*version\s*=\s*'([^']+)'.*/\1/")
+          echo "PLUGIN_VERSION=v${PLUGIN_VERSION#v}" >> $GITHUB_ENV
 
       - name: Check plugin in build.gradle matches tag
         if: github.ref_type == 'tag'
         run: |
           PLUGIN_VERSION_TAG="${{ github.ref_name }}"
-          PLUGIN_VERSION_GRADLE=$(grep -E "version\s*=" build.gradle | head -1 | sed -E "s/.*version\s*=\s*'([^']+)'.*/\1/")
+          PLUGIN_VERSION_GRADLE="${{ env.PLUGIN_VERSION }}"
 
-          if [[ "${PLUGIN_VERSION_TAG#v}" != "${PLUGIN_VERSION_GRADLE}" ]]; then
-            echo "Plugin version in build.gradle (${PLUGIN_VERSION_GRADLE}) does not match tag (${PLUGIN_VERSION_TAG})"
+          if [[ "${PLUGIN_VERSION_TAG#v}" != "${PLUGIN_VERSION_GRADLE#v}" ]]; then
+            echo "Plugin version in build.gradle (${PLUGIN_VERSION_GRADLE#v}) does not match tag (${PLUGIN_VERSION_TAG#v})"
             exit 1
           else
             echo "Plugin version in build.gradle matches tag"
           fi
 
       - name: Setup Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           architecture: x64
@@ -81,15 +74,16 @@ jobs:
 
       - name: Update name of build artifact
         run: |
-          echo "Renaming build artifact to nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ env.FUZZBALL_VERSION }}.zip"
-          mv build/distributions/nf-fuzzball-${{ env.PLUGIN_VERSION }}.zip build/distributions/nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ env.FUZZBALL_VERSION }}.zip
+          aname="nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ env.FUZZBALL_VERSION }}.zip"
+          echo "Renaming build artifact to ${aname}"
+          mv build/distributions/nf-fuzzball-*.zip build/distributions/${aname}
 
       - name: Create or update release and attach artifact
-        if: github.event.inputs.publish_release == 'true' || github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && (github.event_name == 'push' || github.event.inputs.publish_release == 'true')
         uses: ncipollo/release-action@v1
         with:
-          name: Release v${{ env.PLUGIN_VERSION }}
-          tag: v${{ env.PLUGIN_VERSION }}
+          name: Release ${{ env.PLUGIN_VERSION }}
+          tag: ${{ env.PLUGIN_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
           artifacts: "build/distributions/nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ env.FUZZBALL_VERSION }}.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,60 +36,63 @@ jobs:
         id: set-matrix
         run: |
           # Find available schema versions and determine latest
-          AVAILABLE_SCHEMAS=$(ls code-generation/schemas/fuzzball-v*-openapi.json | sed 's/.*fuzzball-v\([^-]*\)-.*/v\1/' | sort -V)
-          LATEST_SCHEMA=$(echo "$AVAILABLE_SCHEMAS" | tail -1)
-          echo "Available schemas: $(echo $AVAILABLE_SCHEMAS | tr '\n' ' ')"
+          mapfile -t AVAILABLE_SCHEMAS < <(find code-generation/schemas/ -name 'fuzzball-v*-openapi.json' | sed 's/.*fuzzball-v\([^-]*\)-.*/v\1/' | sort -V)
+          LATEST_SCHEMA="${AVAILABLE_SCHEMAS[-1]}"
+          echo "Available schemas: ${AVAILABLE_SCHEMAS[*]}"
           echo "Latest schema detected: $LATEST_SCHEMA"
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # PR: Build only latest for testing
-            MATRIX=$(jq -n --arg v "$LATEST_SCHEMA" '{fuzzball_version: [$v]}')
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            SELECTED_VERSIONS=( "${LATEST_SCHEMA}" )
             echo "PR build: using latest schema $LATEST_SCHEMA"
           elif [ "${{ github.ref_type }}" = "tag" ]; then
-            # Tag push: Build only latest for release
-            MATRIX=$(jq -n --arg v "$LATEST_SCHEMA" '{fuzzball_version: [$v]}')
+            SELECTED_VERSIONS=( "${LATEST_SCHEMA}" )
             echo "Tag build: using latest schema $LATEST_SCHEMA"
           else
             # Manual dispatch: Parse input string
             INPUT_VERSIONS="${{ github.event.inputs.schema_versions }}"
             echo "Input versions: $INPUT_VERSIONS"
 
-            if [ "$INPUT_VERSIONS" = "all" ]; then
-              SELECTED_VERSIONS=$(echo "$AVAILABLE_SCHEMAS" | tr '\n' ' ')
-              echo "Building all available versions: $SELECTED_VERSIONS"
+            if [[ "$INPUT_VERSIONS" == "all" ]]; then
+              SELECTED_VERSIONS=( "${AVAILABLE_SCHEMAS[@]}" )
+              echo "Building all available versions: ${SELECTED_VERSIONS[*]}"
             elif [ "$INPUT_VERSIONS" = "latest" ]; then
-              SELECTED_VERSIONS="$LATEST_SCHEMA"
-              echo "Building latest version: $SELECTED_VERSIONS"
+              SELECTED_VERSIONS=( "$LATEST_SCHEMA" )
+              echo "Building latest version: ${SELECTED_VERSIONS[*]}"
             else
               # Parse comma-separated list and validate
-              SELECTED_VERSIONS=$(echo "$INPUT_VERSIONS" | tr ',' ' ' | tr -s ' ')
-              echo "Building specified versions: $SELECTED_VERSIONS"
-            fi
+              mapfile -t _VERSIONS < <( sed 's/,/\n/g' <<< "${INPUT_VERSIONS}" | tr -d " " )
 
-            # Validate selected versions exist and construct matrix
-            VALID_VERSIONS=""
-            for version in $SELECTED_VERSIONS; do
-              if echo "$AVAILABLE_SCHEMAS" | grep -q "^${version}$"; then
-                VALID_VERSIONS="$VALID_VERSIONS $version"
-              else
-                echo "Warning: Schema version '$version' not found in available schemas: $(echo $AVAILABLE_SCHEMAS | tr '\n' ' ')" >&2
-                echo "Skipping invalid version: $version" >&2
-              fi
-            done
+              # Validate selected versions exist and construct matrix
+              SELECTED_VERSIONS=()
+              for version in "${_VERSIONS[@]}"; do
+                # Check if version exists in available schemas array
+                found=false
+                for available in "${AVAILABLE_SCHEMAS[@]}"; do
+                  if [[ "$available" == "$version" ]]; then
+                    found=true
+                    break
+                  fi
+                done
+                if [[ "$found" == "true" ]]; then
+                  SELECTED_VERSIONS+=( "$version" )
+                else
+                  echo "Warning: Schema version '$version' not found in available schemas: ${AVAILABLE_SCHEMAS[*]}" >&2
+                  echo "Skipping invalid version: $version" >&2
+                fi
+              done
+            fi
 
             # If no valid versions found, default to latest
-            if [ -z "$VALID_VERSIONS" ]; then
+            if [[ "${#SELECTED_VERSIONS[@]}" -eq 0 ]]; then
               echo "No valid versions found, defaulting to latest: $LATEST_SCHEMA" >&2
-              VALID_VERSIONS="$LATEST_SCHEMA"
+              SELECTED_VERSIONS+=( "$LATEST_SCHEMA" )
             fi
 
-            # Construct matrix with valid versions
-            MATRIX=$(echo "$VALID_VERSIONS" | tr ' ' '\n' | grep -v '^$' | jq -Rs 'split("\n") | map(select(. != "")) | {fuzzball_version: .}')
-
-            echo "Manual build: building versions$(echo $VALID_VERSIONS | tr ' ' '\n' | sed 's/^/ /')"
+            echo "Manual build: building versions: ${SELECTED_VERSIONS[*]}"
           fi
 
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          # Output matrix in correct format for GitHub Actions
+          echo "matrix=$(jq -cn '{"fuzzball_version": $ARGS.positional}' --args "${SELECTED_VERSIONS[@]}")" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build nf-fuzzball
@@ -112,20 +115,20 @@ jobs:
           SCHEMA_FILE="code-generation/schemas/fuzzball-${FUZZBALL_VERSION}-openapi.json"
 
           # Validate schema file exists
-          if [ ! -f "$SCHEMA_FILE" ]; then
+          if [[ ! -f "$SCHEMA_FILE" ]]; then
             echo "Error: Schema file $SCHEMA_FILE does not exist"
             exit 1
           fi
 
-          echo "FUZZBALL_VERSION=$FUZZBALL_VERSION" >> $GITHUB_ENV
-          echo "SCHEMA_FILE=$SCHEMA_FILE" >> $GITHUB_ENV
+          echo "FUZZBALL_VERSION=$FUZZBALL_VERSION" >> "$GITHUB_ENV"
+          echo "SCHEMA_FILE=$SCHEMA_FILE" >> "$GITHUB_ENV"
           echo "Building for Fuzzball version: $FUZZBALL_VERSION using $SCHEMA_FILE"
 
       - name: Set plugin version (starts with 'v')
         run: |
           # PLUGIN_VERSION always comes from gradle but we make sure it also starts with a v
-          PLUGIN_VERSION=$(grep -E "version\s*=" build.gradle | head -1 | sed -E "s/.*version\s*=\s*'([^']+)'.*/\1/")
-          echo "PLUGIN_VERSION=v${PLUGIN_VERSION#v}" >> $GITHUB_ENV
+          PLUGIN_VERSION="$(grep -E "version\s*=" build.gradle | head -1 | sed -E "s/.*version\s*=\s*'([^']+)'.*/\1/")"
+          echo "PLUGIN_VERSION=v${PLUGIN_VERSION#v}" >> "$GITHUB_ENV"
 
       - name: Check plugin in build.gradle matches tag
         if: github.ref_type == 'tag'
@@ -159,8 +162,8 @@ jobs:
         run: |
           aname="nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ matrix.fuzzball_version }}.zip"
           echo "Renaming build artifact to ${aname}"
-          mv build/distributions/nf-fuzzball-*.zip build/distributions/${aname}
-          echo "ARTIFACT_NAME=${aname}" >> $GITHUB_ENV
+          mv build/distributions/nf-fuzzball-*.zip "build/distributions/${aname}"
+          echo "ARTIFACT_NAME=${aname}" >> "$GITHUB_ENV"
 
       - name: Create or update release and attach artifact
         if: github.ref_type == 'tag' && (github.event_name == 'push' || github.event.inputs.publish_release == 'true')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,30 +13,113 @@ on:
         required: true
         default: false
         type: boolean
+      schema_versions:
+        description: 'Fuzzball versions to build - Examples: "latest", "all", "v3.0", "v2.2,v3.0"'
+        required: true
+        default: 'latest'
+        type: string
 
 jobs:
-  build:
-    name: Build nf-fuzzball
+  determine-matrix:
+    name: Determine build matrix
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Determine which schemas to build
+        id: set-matrix
+        run: |
+          # Find available schema versions and determine latest
+          AVAILABLE_SCHEMAS=$(ls code-generation/schemas/fuzzball-v*-openapi.json | sed 's/.*fuzzball-v\([^-]*\)-.*/v\1/' | sort -V)
+          LATEST_SCHEMA=$(echo "$AVAILABLE_SCHEMAS" | tail -1)
+          echo "Available schemas: $(echo $AVAILABLE_SCHEMAS | tr '\n' ' ')"
+          echo "Latest schema detected: $LATEST_SCHEMA"
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # PR: Build only latest for testing
+            MATRIX=$(jq -n --arg v "$LATEST_SCHEMA" '{fuzzball_version: [$v]}')
+            echo "PR build: using latest schema $LATEST_SCHEMA"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            # Tag push: Build only latest for release
+            MATRIX=$(jq -n --arg v "$LATEST_SCHEMA" '{fuzzball_version: [$v]}')
+            echo "Tag build: using latest schema $LATEST_SCHEMA"
+          else
+            # Manual dispatch: Parse input string
+            INPUT_VERSIONS="${{ github.event.inputs.schema_versions }}"
+            echo "Input versions: $INPUT_VERSIONS"
+
+            if [ "$INPUT_VERSIONS" = "all" ]; then
+              SELECTED_VERSIONS=$(echo "$AVAILABLE_SCHEMAS" | tr '\n' ' ')
+              echo "Building all available versions: $SELECTED_VERSIONS"
+            elif [ "$INPUT_VERSIONS" = "latest" ]; then
+              SELECTED_VERSIONS="$LATEST_SCHEMA"
+              echo "Building latest version: $SELECTED_VERSIONS"
+            else
+              # Parse comma-separated list and validate
+              SELECTED_VERSIONS=$(echo "$INPUT_VERSIONS" | tr ',' ' ' | tr -s ' ')
+              echo "Building specified versions: $SELECTED_VERSIONS"
+            fi
+
+            # Validate selected versions exist and construct matrix
+            VALID_VERSIONS=""
+            for version in $SELECTED_VERSIONS; do
+              if echo "$AVAILABLE_SCHEMAS" | grep -q "^${version}$"; then
+                VALID_VERSIONS="$VALID_VERSIONS $version"
+              else
+                echo "Warning: Schema version '$version' not found in available schemas: $(echo $AVAILABLE_SCHEMAS | tr '\n' ' ')" >&2
+                echo "Skipping invalid version: $version" >&2
+              fi
+            done
+
+            # If no valid versions found, default to latest
+            if [ -z "$VALID_VERSIONS" ]; then
+              echo "No valid versions found, defaulting to latest: $LATEST_SCHEMA" >&2
+              VALID_VERSIONS="$LATEST_SCHEMA"
+            fi
+
+            # Construct matrix with valid versions
+            MATRIX=$(echo "$VALID_VERSIONS" | tr ' ' '\n' | grep -v '^$' | jq -Rs 'split("\n") | map(select(. != "")) | {fuzzball_version: .}')
+
+            echo "Manual build: building versions$(echo $VALID_VERSIONS | tr ' ' '\n' | sed 's/^/ /')"
+          fi
+
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build nf-fuzzball
+    needs: determine-matrix
+    runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      matrix: ${{fromJson(needs.determine-matrix.outputs.matrix)}}
 
     steps:
-
-      - name: Get Fuzzball version on stable (starts with 'v')
-        run: |
-          FUZZBALL_VERSION=$(curl -s https://api.stable.fuzzball.ciq.dev/v2/version | jq -r '.version')
-          # make sure Fuzzball version starts with a v
-          echo "FUZZBALL_VERSION=v${FUZZBALL_VERSION#v}" >> $GITHUB_ENV
-
-      - name: Environment
-        run: env | sort
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: true
+
+      - name: Set Fuzzball version and validate schema
+        run: |
+          FUZZBALL_VERSION="${{ matrix.fuzzball_version }}"
+          SCHEMA_FILE="code-generation/schemas/fuzzball-${FUZZBALL_VERSION}-openapi.json"
+
+          # Validate schema file exists
+          if [ ! -f "$SCHEMA_FILE" ]; then
+            echo "Error: Schema file $SCHEMA_FILE does not exist"
+            exit 1
+          fi
+
+          echo "FUZZBALL_VERSION=$FUZZBALL_VERSION" >> $GITHUB_ENV
+          echo "SCHEMA_FILE=$SCHEMA_FILE" >> $GITHUB_ENV
+          echo "Building for Fuzzball version: $FUZZBALL_VERSION using $SCHEMA_FILE"
 
       - name: Set plugin version (starts with 'v')
         run: |
@@ -65,7 +148,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Compile
-        run: ./gradlew assemble
+        run: ./gradlew assemble -PopenapiFile="${{ env.SCHEMA_FILE }}"
 
       - name: Tests
         run: ./gradlew check
@@ -74,9 +157,10 @@ jobs:
 
       - name: Update name of build artifact
         run: |
-          aname="nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ env.FUZZBALL_VERSION }}.zip"
+          aname="nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ matrix.fuzzball_version }}.zip"
           echo "Renaming build artifact to ${aname}"
           mv build/distributions/nf-fuzzball-*.zip build/distributions/${aname}
+          echo "ARTIFACT_NAME=${aname}" >> $GITHUB_ENV
 
       - name: Create or update release and attach artifact
         if: github.ref_type == 'tag' && (github.event_name == 'push' || github.event.inputs.publish_release == 'true')
@@ -86,5 +170,5 @@ jobs:
           tag: ${{ env.PLUGIN_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
-          artifacts: "build/distributions/nf-fuzzball-${{ env.PLUGIN_VERSION }}-stable-${{ env.FUZZBALL_VERSION }}.zip"
+          artifacts: "build/distributions/${{ env.ARTIFACT_NAME }}"
           artifactContentType: "application/zip"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # locally customizable script to push a build of a development version to a s3/http accessible location for testing
 push_dev.local
+claude.md
 
 # ignore the code generator jars downloaded by the fuzzball api generation script
 openapi-generator-cli*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .venv
 .ruff_cache
 .envrc
+*.pyc
 
 # ignore the code generator jars downloaded by the fuzzball api generation script
 openapi-generator-cli*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 .envrc
 *.pyc
 
+# locally customizable script to push a build of a development version to a s3/http accessible location for testing
+push_dev.local
+
 # ignore the code generator jars downloaded by the fuzzball api generation script
 openapi-generator-cli*.jar
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,3 +226,36 @@ jobs:
 }
 
 ```
+
+## Branching Strategy
+
+### Branch Structure
+
+- main: Production-ready code, always deployable
+- vMAJOR.MINOR.x: Release branches for major.minor versions (e.g., v0.1.x, v1.0.x)
+- Feature branches: Short-lived branches for development
+
+### Tagging Strategy
+
+- vMAJOR.MINOR.0 tags on vMAJOR.MINOR.x branches (initial release)
+- vMAJOR.MINOR.Z patch tags on vMAJOR.MINOR.x branches
+- All tags follow semantic versioning
+
+Example:
+```
+main ←────────────────────────────────────
+↓
+v0.1.x ── v0.1.0 ── v0.1.1 ── v0.1.2
+↓
+v1.0.x ── v1.0.0 ── v1.0.1
+```
+
+### Workflow Process
+
+1. Feature Development: Create feature branch from main → PR to main
+2. Release Preparation: Create vMAJOR.MINOR.x branch from main
+3. Release Tagging: Tag vMAJOR.MINOR.0 on vMAJOR.MINOR.x branch
+4. Patch Releases: Cherry-pick fixes to vMAJOR.MINOR.x → tag vMAJOR.MINOR.Z
+5. The `build.gradle` version on main should be the next minor version up
+   from the most recent release branch. That change is made after creation of
+   a release branch.

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ sdk:
 sdk-full:
 	code-generation/generate --url "$(OPENAPI_URL)" --keep temp/fuzzball-sdk
 
-# temporary rule for pushing the plugin to S3
-push: assemble
-	aws s3 cp build/distributions/nf-fuzzball-$(VERSION).zip s3://co-ciq-misc-support/nf-fuzzball/v$(VERSION)/nf-fuzzball-$(VERSION)-stable-$(FB_VERSION).zip
+# Rule for pushing dev versions of the plugin to a local plugin repository that can
+# be used with --plugin-base-uri
+# Depends on the script `push_dev.local` to work. This script is not included in the repository. Create
+# your own to customize.
+push_dev: assemble
+	if [ -e push_dev.local ] ; then \
+	    ./push_dev.local v$(VERSION) $(FB_VERSION); \
+	else \
+	    echo "Create a 'push_dev' script to build the plugin and push it to a https or s3 accessible location"; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ help: ## Show this help message
 	@echo ""
 	@echo "Available targets:"
 	@echo ""
+	# assemble make target descriptions from special comments starting with '##' appended to the target line
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo ""
 	@echo "Environment Variables:"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+// Copyright 2025 CIQ, Inc. All rights reserved.
+
 plugins {
     // https://plugins.gradle.org/plugin/io.nextflow.nextflow-plugin
     // https://github.com/nextflow-io/nextflow-plugin-gradle
@@ -39,12 +41,21 @@ tasks.register('generateFuzzballSdk', Exec) {
     final codegenFile = codegenDir.file('generate')
     group = 'build'
     description = 'Generate Fuzzball SDK'
-    def openapiUrl = project.hasProperty('openapiUrl') ? project.property('openapiUrl') : 'https://api.stable.fuzzball.ciq.dev/v2/schema'
     inputs.files(
         fileTree(dir: codegenDir, include: ['**/*.yaml', '**/*.mustache', '**/*.sh'])
     )
     outputs.dir generatedSdkDir
-    commandLine codegenFile.getAsFile().getAbsolutePath(), "--url=${openapiUrl}", generatedSdkDir.get().getAsFile().getAbsolutePath()
+
+    // Build commandLine args based on which property was provided
+    def args = [codegenFile.getAsFile().getAbsolutePath()]
+    if (project.hasProperty('openapiFile')) {
+        args.add("--file=${project.property('openapiFile')}")
+    } else if (project.hasProperty('openapiUrl')) {
+        args.add("--url=${project.property('openapiUrl')}")
+    }
+    args.add(generatedSdkDir.get().getAsFile().getAbsolutePath())
+
+    commandLine args
 }
 compileGroovy.dependsOn tasks.named('generateFuzzballSdk')
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'io.nextflow.nextflow-plugin' version '0.0.1-alpha6'
+    // https://plugins.gradle.org/plugin/io.nextflow.nextflow-plugin
+    id 'io.nextflow.nextflow-plugin' version '1.0.0-beta6'
 }
 
 dependencies {
@@ -11,7 +12,7 @@ dependencies {
 }
 
 // plugin version
-version = '0.0.1'
+version = '0.1.0'
 
 nextflowPlugin {
     // minimum nextflow version

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     // https://plugins.gradle.org/plugin/io.nextflow.nextflow-plugin
-    id 'io.nextflow.nextflow-plugin' version '1.0.0-beta6'
+    // https://github.com/nextflow-io/nextflow-plugin-gradle
+    id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.6'
 }
 
 dependencies {
@@ -26,12 +27,6 @@ nextflowPlugin {
         'com.ciq.fuzzball.FuzzballExecutor'
     ]
 
-    publishing {
-        registry {
-            url = 'https://plugins.nextflow.io/api'
-            authToken = project.findProperty('registry_access_token')
-        }
-    }
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.1'
 }
 
-// plugin version
+// plugin version - gradle by convention seems to not use v prefixes. That does
+// cause some issues in other places but we'll stick with convention
 version = '0.1.0'
 
 nextflowPlugin {

--- a/code-generation/generate
+++ b/code-generation/generate
@@ -1,19 +1,23 @@
 #! /bin/bash
 #>SYNOPSIS
-#>  generate [--keep] [--url=URL] [--file=FILE] PATH
+#>  generate [--keep] [--url=URL|--file=FILE] PATH
 #>  generate --help
+#>
 #>DESCRIPTION
 #>  Generate a groovy fuzzball-sdk from the openapi spec. Uses several custom templates
 #>  to generate more modern groovy code including replacing the unmaintained httpbuilder-ng with
 #>  okhttp3.
-#>  If PATH exists it will be deleted and replaced with the generated code.
-#>  --keep
-#>      Keep the full generated project. Othewise only the groovy files are copied.
+#>
+#>  PATH
+#>      Locate to save the auto-generated SDK to. If PATH exists it will be deleted and replaced
+#>      with the generated code.
 #>  --url
-#>      URL of the OpenAPI spec to fetch (defaults to https://api.stable.fuzzball.ciq.dev/v2/schema)
+#>      URL of the OpenAPI spec to fetch (defaults to https://api.stable.fuzzball.ciq.dev/v3/schema)
 #>  --file
 #>      File of the OpenAPI spec. Defaults to none and when specified takes precedence over
-#>      --url. When defined it expects the filename to be in the format fuzzball-<VERSION>-openapi.json
+#>      --url.
+#>  --keep
+#>      Keep the full generated project. Othewise only the groovy files are copied.
 #>
 #>Copyright 2025 CIQ, Inc. All rights reserved.
 
@@ -23,12 +27,11 @@ EXIT_DOWNLOAD_FAILED=101
 EXIT_CODEGEN_FAILED=102
 EXIT_SED_FAILED=103
 EXIT_MISSING_FILE=104
-EXIT_BAD_SPEC_FILENAME=105
-EXIT_MISSING_JQ=106
+EXIT_MISSING_JQ=105
 
 keep=false
 path="__none__"
-url="https://api.stable.fuzzball.ciq.dev/v2/schema"
+url="https://api.stable.fuzzball.ciq.dev/v3/schema"
 specfile="__none__"
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -47,7 +50,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --file=*)
-            specfile="${1#--spec=}"
+            specfile="${1#--file=}"
             ;;
         --help)
             awk '/^#>/{sub(/^#>/,"");print}' "$0"
@@ -59,11 +62,6 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
-
-if ! command -v jq >/dev/null 2>&1 ; then
-    echo "Error: 'jq' is required for this script"
-    exit $EXIT_MISSING_JQ
-fi
 
 if [[ "${path:-__none__}" == "__none__" ]]; then
     awk '/^#>/{sub(/^#>/,"");print}' "$0"
@@ -82,17 +80,8 @@ if [[ "${specfile}" != "__none__" ]]; then
         echo "Error: ${specfile} does not exist"
         exit $EXIT_MISSING_FILE
     fi
-    if [[ "${specfile}" =~ fuzzball-(v[^-]+)-openapi.json ]]; then
-        spec="${specfile}"
-        fb_version="${BASH_REMATCH[1]}"
-    else
-        echo "Error: If supplying an OpenAPI spect with --file the filename is expected to match fuzzball-<VERSION>-openapi.json"
-        exit $EXIT_BAD_SPEC_FILENAME
-    fi
-else
-    fb_version="$(curl -H 'Accept: application/json' -s "${url%/schema}/version" | jq -r '.version')"
+    spec="${specfile}"
 fi
-
 
 ver=7.13.0
 scriptd="$(cd "$(dirname "$0")" && pwd)"
@@ -151,5 +140,4 @@ fi
 printf -- "------------------------------------------------\n"
 printf "Fuzzball SDK generated in %s\n" "${path}"
 printf "  source: %s\n" "${url}"
-printf "  version: %s\n" "${fb_version}"
 printf -- "------------------------------------------------\n"

--- a/code-generation/generate
+++ b/code-generation/generate
@@ -1,6 +1,6 @@
 #! /bin/bash
 #>SYNOPSIS
-#>  generate [--keep|--src] PATH
+#>  generate [--keep] [--url=URL] [--file=FILE] PATH
 #>  generate --help
 #>DESCRIPTION
 #>  Generate a groovy fuzzball-sdk from the openapi spec. Uses several custom templates
@@ -9,6 +9,11 @@
 #>  If PATH exists it will be deleted and replaced with the generated code.
 #>  --keep
 #>      Keep the full generated project. Othewise only the groovy files are copied.
+#>  --url
+#>      URL of the OpenAPI spec to fetch (defaults to https://api.stable.fuzzball.ciq.dev/v2/schema)
+#>  --file
+#>      File of the OpenAPI spec. Defaults to none and when specified takes precedence over
+#>      --url. When defined it expects the filename to be in the format fuzzball-<VERSION>-openapi.json
 #>
 #>Copyright 2025 CIQ, Inc. All rights reserved.
 
@@ -17,10 +22,14 @@ EXIT_NODOWNLOADER=100
 EXIT_DOWNLOAD_FAILED=101
 EXIT_CODEGEN_FAILED=102
 EXIT_SED_FAILED=103
+EXIT_MISSING_FILE=104
+EXIT_BAD_SPEC_FILENAME=105
+EXIT_MISSING_JQ=106
 
 keep=false
 path="__none__"
 url="https://api.stable.fuzzball.ciq.dev/v2/schema"
+specfile="__none__"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --keep)
@@ -33,6 +42,13 @@ while [[ $# -gt 0 ]]; do
         --url=*)
             url="${1#--url=}"
             ;;
+        --file)
+            specfile="$2"
+            shift
+            ;;
+        --file=*)
+            specfile="${1#--spec=}"
+            ;;
         --help)
             awk '/^#>/{sub(/^#>/,"");print}' "$0"
             exit 0
@@ -44,6 +60,11 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
+if ! command -v jq >/dev/null 2>&1 ; then
+    echo "Error: 'jq' is required for this script"
+    exit $EXIT_MISSING_JQ
+fi
+
 if [[ "${path:-__none__}" == "__none__" ]]; then
     awk '/^#>/{sub(/^#>/,"");print}' "$0"
     exit 1
@@ -51,6 +72,27 @@ fi
 if [[ ! "$path" =~ ^/ ]]; then
     path="${PWD}/${path}"
 fi
+
+spec="${url}"
+if [[ "${specfile}" != "__none__" ]]; then
+    if [[ ! "${specfile}" =~ ^/ ]]; then
+        specfile="${PWD}/${specfile}"
+    fi
+    if [[ ! -e "${specfile}" ]]; then
+        echo "Error: ${specfile} does not exist"
+        exit $EXIT_MISSING_FILE
+    fi
+    if [[ "${specfile}" =~ fuzzball-(v[^-]+)-openapi.json ]]; then
+        spec="${specfile}"
+        fb_version="${BASH_REMATCH[1]}"
+    else
+        echo "Error: If supplying an OpenAPI spect with --file the filename is expected to match fuzzball-<VERSION>-openapi.json"
+        exit $EXIT_BAD_SPEC_FILENAME
+    fi
+else
+    fb_version="$(curl -H 'Accept: application/json' -s "${url%/schema}/version" | jq -r '.version')"
+fi
+
 
 ver=7.13.0
 scriptd="$(cd "$(dirname "$0")" && pwd)"
@@ -79,7 +121,7 @@ java -jar "./${gen}" \
 	  -g groovy \
 	  -c generate_config.yaml \
 	  -o  "${tmp}/${name}" \
-	  -i "${url}" || exit $EXIT_CODEGEN_FAILED
+	  -i "${spec}" || exit $EXIT_CODEGEN_FAILED
 
 # - i could not remove the imports for io.swagger.annotations from the generated code without a custom generator
 # - the abstract java generation class that is the base class for the groovy generator includes a hardcoded mapping of URI -> java.net.URI
@@ -109,5 +151,5 @@ fi
 printf -- "------------------------------------------------\n"
 printf "Fuzzball SDK generated in %s\n" "${path}"
 printf "  source: %s\n" "${url}"
-printf "  version: %s\n" "$(curl -H 'Accept: application/json' -s "${url%/schema}/version" | jq -r '.version')"
+printf "  version: %s\n" "${fb_version}"
 printf -- "------------------------------------------------\n"

--- a/code-generation/groovy-okhttp-sync/ApiUtils.mustache
+++ b/code-generation/groovy-okhttp-sync/ApiUtils.mustache
@@ -8,14 +8,22 @@ import groovy.json.JsonGenerator
 import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
-import org.apache.commons.lang3.StringUtils
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
 import okhttp3.HttpUrl
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
+import org.apache.commons.lang3.StringUtils
 
 import {{apiPackage}}.ApiConfig
 
@@ -25,6 +33,7 @@ import {{apiPackage}}.ApiConfig
 @Slf4j
 @CompileStatic
 class ApiUtils {
+    private static final Logger staticLog = LoggerFactory.getLogger(ApiUtils.class)
     static final String GET = 'GET'
     static final String POST = 'POST'
     static final String PUT = 'PUT'
@@ -38,10 +47,63 @@ class ApiUtils {
             }
             .build()
 
-    static final OkHttpClient CLIENT = new OkHttpClient.Builder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .build()
+    /**
+     * Creates an OkHttpClient with optional custom CA certificate support.
+     * Checks for FB_CA_CERT environment variable to configure SSL with custom certificates.
+     *
+     * @return Configured OkHttpClient instance
+     */
+    private static OkHttpClient createHttpClient() {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+
+        // Check for custom CA certificate
+        String caCertPath = System.getenv('FB_CA_CERT')
+        if (caCertPath) {
+            try {
+                // Load the custom CA certificate
+                File caCertFile = new File(caCertPath)
+                if (caCertFile.exists()) {
+                    staticLog.debug("Loading custom CA certificate from: ${caCertPath}")
+
+                    CertificateFactory cf = CertificateFactory.getInstance('X.509')
+                    X509Certificate caCert = (X509Certificate) cf.generateCertificate(
+                        new FileInputStream(caCertFile)
+                    )
+
+                    // Create KeyStore with the custom CA
+                    KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
+                    keyStore.load(null, null)
+                    keyStore.setCertificateEntry('ca', caCert)
+
+                    // Create TrustManager
+                    TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                        TrustManagerFactory.getDefaultAlgorithm()
+                    )
+                    tmf.init(keyStore)
+
+                    // Configure SSL context
+                    SSLContext sslContext = SSLContext.getInstance('TLS')
+                    sslContext.init(null, tmf.getTrustManagers(), null)
+
+                    builder.sslSocketFactory(sslContext.getSocketFactory(),
+                                           (X509TrustManager) tmf.getTrustManagers()[0])
+
+                    staticLog.info("Successfully configured custom CA certificate from ${caCertPath}")
+                } else {
+                    staticLog.warn("CA certificate file not found: ${caCertPath}")
+                }
+            } catch (Exception e) {
+                staticLog.error("Failed to configure custom CA certificate: ${e.message}", e)
+                // Continue with default SSL settings
+            }
+        }
+
+        return builder.build()
+    }
+
+    static final OkHttpClient CLIENT = createHttpClient()
 
     final ApiConfig config
 

--- a/code-generation/schemas/fuzzball-v2.1-openapi.json
+++ b/code-generation/schemas/fuzzball-v2.1-openapi.json
@@ -1,0 +1,5232 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Fuzzball API",
+    "version": "2.0",
+    "contact": {
+      "name": "CtrlIQ, Inc",
+      "url": "https://ciq.co",
+      "email": "info@ciq.co"
+    }
+  },
+  "tags": [
+    {
+      "name": "AccountService"
+    },
+    {
+      "name": "ApplicationService"
+    },
+    {
+      "name": "ClusterService"
+    },
+    {
+      "name": "OrganizationService"
+    },
+    {
+      "name": "ProvisionService"
+    },
+    {
+      "name": "SecretService"
+    },
+    {
+      "name": "StorageClassService"
+    },
+    {
+      "name": "StorageVolumeService"
+    },
+    {
+      "name": "UserService"
+    },
+    {
+      "name": "VersionService"
+    },
+    {
+      "name": "WorkflowService"
+    },
+    {
+      "name": "WorkflowGatewayService"
+    },
+    {
+      "name": "WorkflowGenerateService"
+    }
+  ],
+  "basePath": "/v2",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/accounts": {
+      "get": {
+        "operationId": "ListAccounts",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListAccountsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "showUserAccounts",
+            "description": "only valid for org/platform owners, by default all users/owners will only\nsee their own user account",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateAccountRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/update-user-account": {
+      "get": {
+        "operationId": "UpdateUserAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UpdateUserAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}": {
+      "get": {
+        "operationId": "GetAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members": {
+      "get": {
+        "operationId": "ListAccountMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "ACCOUNT_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "AddAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members/{userId}": {
+      "delete": {
+        "operationId": "RemoveAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "ACCOUNT_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/token": {
+      "get": {
+        "operationId": "SelectAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SelectAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/applications": {
+      "get": {
+        "operationId": "ListApplications",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListApplicationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/categories": {
+      "get": {
+        "operationId": "ListApplicationCategories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListApplicationCategoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "operationId": "GetApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:disable": {
+      "put": {
+        "operationId": "DisableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:enable": {
+      "put": {
+        "operationId": "EnableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:render": {
+      "post": {
+        "operationId": "RenderApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:copy": {
+      "post": {
+        "operationId": "CopyApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CopyApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:render": {
+      "post": {
+        "operationId": "RenderApplicationTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/cluster/{id}": {
+      "get": {
+        "operationId": "GetCluster",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/clusters": {
+      "get": {
+        "operationId": "ListClusters",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListClustersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/organization": {
+      "get": {
+        "operationId": "GetOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrganizationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members": {
+      "get": {
+        "operationId": "ListOrganizationMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "post": {
+        "operationId": "AddOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddOrganizationMemberRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members/{id}": {
+      "delete": {
+        "operationId": "RemoveOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/secrets": {
+      "get": {
+        "operationId": "ListOrganizationSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/organization/secrets/{id}": {
+      "get": {
+        "operationId": "GetOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrganizationSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/profile": {
+      "get": {
+        "operationId": "GetUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "UserService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/avatar": {
+      "patch": {
+        "operationId": "UpdateUserProfileAvatar",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileAvatarRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/settings": {
+      "patch": {
+        "summary": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+        "operationId": "UpdateUserProfileSettings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileSettingsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/provision/definitions": {
+      "get": {
+        "operationId": "ListProvisionDefinitions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListProvisionDefinitionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "inactive",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionService"
+        ]
+      }
+    },
+    "/provision/definitions/{id}": {
+      "get": {
+        "operationId": "GetProvisionDefinition",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisionDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionService"
+        ]
+      }
+    },
+    "/secrets": {
+      "get": {
+        "operationId": "ListSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/secrets/{id}": {
+      "get": {
+        "operationId": "GetSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/storage-classes": {
+      "get": {
+        "operationId": "ListStorageClasses",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListStorageClassesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/storage-classes/{id}": {
+      "get": {
+        "operationId": "GetStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/StorageClassInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/stream/workflow/attach": {
+      "post": {
+        "operationId": "WorkflowGatewayAttach",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayAttachResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayAttachResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowGatewayAttachRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/exec": {
+      "post": {
+        "operationId": "WorkflowGatewayExec",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayExecResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayExecResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowGatewayExecRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/generate": {
+      "post": {
+        "operationId": "GenerateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/GenerateWorkflowServerMessage"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of GenerateWorkflowServerMessage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GenerateWorkflowClientMessage"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGenerateService"
+        ]
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Get the fuzzball agent version",
+        "operationId": "VersionGet",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VersionGetResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "VersionService"
+        ]
+      }
+    },
+    "/volumes": {
+      "get": {
+        "operationId": "ListVolumes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListVolumesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateVolumeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}": {
+      "get": {
+        "operationId": "GetVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateVolumeBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}:set-status": {
+      "patch": {
+        "operationId": "SetVolumeStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SetVolumeStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetVolumeStatusBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/workflows": {
+      "get": {
+        "summary": "List workflows",
+        "operationId": "ListWorkflows",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListWorkflowsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "status",
+            "description": "Only return workflows with the given status\n\n - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "summary": "Start a new workflow",
+        "operationId": "StartWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StartWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary": {
+      "get": {
+        "summary": "Get a summary of workflows",
+        "operationId": "GetWorkflowsSummary",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkflowsSummaryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "userWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "otherOwnerWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary/account-owner/details": {
+      "get": {
+        "summary": "Get workflow summary details",
+        "operationId": "GetAccountOwnerWorkflowsSummaryDetails",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetAccountOwnerWorkflowsSummaryDetailsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "requestedStatus",
+            "description": " - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pendingWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "completedWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}": {
+      "get": {
+        "summary": "Get details on a workflow",
+        "operationId": "GetWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Workflow"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners": {
+      "get": {
+        "operationId": "ListWorkflowOwners",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "operationId": "AddWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddWorkflowOwnerBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners/{userId}": {
+      "delete": {
+        "operationId": "RemoveWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:log": {
+      "get": {
+        "operationId": "WorkflowGatewayLog",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayLogResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayLogResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "show.tail",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "show.follow",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "command",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+            ],
+            "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+          },
+          {
+            "name": "name",
+            "description": "Name of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "rank",
+            "description": "Rank of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/workflows/{id}:status": {
+      "get": {
+        "summary": "Get the status on a workflow",
+        "operationId": "GetWorkflowStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkflowStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:stop": {
+      "patch": {
+        "summary": "Stop a workflow",
+        "operationId": "StopWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:score": {
+      "patch": {
+        "summary": "ScoreWorkflow returns the score for a workflow definition.",
+        "operationId": "ScoreWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ScoreWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ScoreWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:validate": {
+      "post": {
+        "summary": "Validate a workflow definition",
+        "operationId": "ValidateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ValidateWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Access": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Access.Type"
+        },
+        "mode": {
+          "$ref": "#/definitions/Mode"
+        }
+      }
+    },
+    "Access.Type": {
+      "type": "string",
+      "enum": [
+        "TYPE_UNSPECIFIED",
+        "FILESYSTEM",
+        "BLOCK"
+      ],
+      "default": "TYPE_UNSPECIFIED",
+      "title": "- BLOCK: BLOCK is not supported yet"
+    },
+    "Account": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "AccountOwnerWorkflowsSummary": {
+      "type": "object",
+      "properties": {
+        "currentWorkflowsStarted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentWorkflowsPending": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "averageWorkflowPendingMilliseconds": {
+          "type": "number",
+          "format": "double"
+        },
+        "workflowsCompleted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "totalAccountUsers": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "AccountOwnerWorkflowsSummaryDetails": {
+      "type": "object",
+      "properties": {
+        "startedWorkflowUsers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pendingWorkflowDetailsResponse": {
+          "$ref": "#/definitions/PendingWorkflowDetailsResponse"
+        },
+        "completedWorkflowsResponse": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        }
+      }
+    },
+    "AccountRelationship": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT_MEMBER",
+        "ACCOUNT_OWNER"
+      ],
+      "default": "ACCOUNT_MEMBER"
+    },
+    "AddAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/AccountRelationship"
+        }
+      }
+    },
+    "AddOrganizationMemberRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/OrganizationRelationship"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "AddWorkflowOwnerBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        }
+      }
+    },
+    "Affinity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Affinity.Type"
+        },
+        "key": {
+          "type": "string"
+        },
+        "filter": {
+          "type": "string"
+        }
+      }
+    },
+    "Affinity.Type": {
+      "type": "string",
+      "enum": [
+        "AFFINITY_UNSPECIFIED",
+        "ANNOTATION",
+        "RESOURCE"
+      ],
+      "default": "AFFINITY_UNSPECIFIED"
+    },
+    "Any": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "Application": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationCategory": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationMetadata": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationOwnerKind": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT",
+        "ORGANIZATION",
+        "PROVIDER"
+      ],
+      "default": "ACCOUNT",
+      "title": "- ACCOUNT: default\n - ORGANIZATION: must be an organization owner to use\n - PROVIDER: only available via direct sql updates (for now)"
+    },
+    "Capability": {
+      "type": "string",
+      "enum": [
+        "CAPABILITY_UNSPECIFIED",
+        "SELINUX"
+      ],
+      "default": "CAPABILITY_UNSPECIFIED"
+    },
+    "Capacity": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "unit": {
+          "$ref": "#/definitions/Unit"
+        }
+      }
+    },
+    "Cluster": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/ClusterKind"
+        },
+        "status": {
+          "$ref": "#/definitions/ClusterStatus"
+        },
+        "apiEndpoint": {
+          "type": "string"
+        },
+        "openapiEndpoint": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "ClusterKind": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_KIND_UNSPECIFIED",
+        "CLUSTER_KIND_ORCHESTRATE",
+        "CLUSTER_KIND_FEDERATE"
+      ],
+      "default": "CLUSTER_KIND_UNSPECIFIED"
+    },
+    "ClusterStatus": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_STATUS_UNSPECIFIED",
+        "CLUSTER_STATUS_UNSYNCED",
+        "CLUSTER_STATUS_SYNCING",
+        "CLUSTER_STATUS_READY",
+        "CLUSTER_STATUS_UNREACHABLE",
+        "CLUSTER_STATUS_ERROR",
+        "CLUSTER_STATUS_DISABLED"
+      ],
+      "default": "CLUSTER_STATUS_UNSPECIFIED"
+    },
+    "Completed": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      },
+      "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+    },
+    "CopyApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        }
+      }
+    },
+    "CreateAccountRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "CreateApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string",
+          "title": "if not provided a default will be set"
+        }
+      }
+    },
+    "CreateSecretRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/SecretScope"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        },
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/ImageDecryptionSecret"
+        }
+      }
+    },
+    "CreateVolumeRequest": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/VolumeDefinition"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "Defaults": {
+      "type": "object",
+      "properties": {
+        "job": {
+          "$ref": "#/definitions/Defaults.Job"
+        }
+      },
+      "description": "Default defines the default settings that should be applied to all jobs in the workflow.\nThese can be overridden at the job level."
+    },
+    "Defaults.Job": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside all job\ncontainers.  Will be overridden by job level env variables."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Defaults.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/Defaults.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        }
+      }
+    },
+    "Defaults.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "Defaults.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/Defaults.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/Defaults.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "Defaults.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "Defaults.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/URI",
+          "description": "Source is the origin of the data. The type of URIs supported are\ndetermined by whether this is specified under ingress or egress."
+        },
+        "destination": {
+          "$ref": "#/definitions/URI",
+          "description": "Destination is the location to move the data. The type of URIs\nsupported are determined by whether this is specified under ingress or\negress."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a data transfer such as max execution time and retries on\nfailure."
+        }
+      },
+      "description": "File specifies details of workflow volume data movement."
+    },
+    "GenerateWorkflowClientMessage": {
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "GenerateWorkflowServerMessage": {
+      "type": "object",
+      "properties": {
+        "workflowYaml": {
+          "type": "string"
+        },
+        "response": {
+          "type": "string"
+        }
+      }
+    },
+    "GetAccountOwnerWorkflowsSummaryDetailsResponse": {
+      "type": "object",
+      "properties": {
+        "accountOwnerWorkflowsSummaryDetails": {
+          "$ref": "#/definitions/AccountOwnerWorkflowsSummaryDetails"
+        }
+      }
+    },
+    "GetWorkflowStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/WorkflowPlan"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "workflowStatus": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "GetWorkflowsSummaryResponse": {
+      "type": "object",
+      "properties": {
+        "userWorkflows": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        },
+        "otherOwnerWorkflows": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        },
+        "accountOwnerWorkflowsSummary": {
+          "$ref": "#/definitions/AccountOwnerWorkflowsSummary"
+        }
+      }
+    },
+    "HTTPSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageDecryptionSecret": {
+      "type": "object",
+      "properties": {
+        "passphrase": {
+          "type": "string"
+        },
+        "pem": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "ListAccountsResponse": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Account"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListApplicationCategoriesResponse": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ApplicationCategory"
+          }
+        }
+      }
+    },
+    "ListApplicationsResponse": {
+      "type": "object",
+      "properties": {
+        "applications": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ApplicationMetadata"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListClustersResponse": {
+      "type": "object",
+      "properties": {
+        "clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Cluster"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListProvisionDefinitionsResponse": {
+      "type": "object",
+      "properties": {
+        "definitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ProvisionDefinition"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListSecretsResponse": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Secret"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListStorageClassesResponse": {
+      "type": "object",
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/StorageClassInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListVolumesResponse": {
+      "type": "object",
+      "properties": {
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/VolumeInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListWorkflowsResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Workflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "MapSecret": {
+      "type": "object",
+      "properties": {
+        "map": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Mode": {
+      "type": "string",
+      "enum": [
+        "MODE_UNSPECIFIED",
+        "SINGLE_NODE_WRITER",
+        "SINGLE_NODE_READER_ONLY",
+        "MULTI_NODE_READER_ONLY",
+        "MULTI_NODE_SINGLE_WRITER",
+        "MULTI_NODE_MULTI_WRITER",
+        "SINGLE_NODE_SINGLE_WRITER",
+        "SINGLE_NODE_MULTI_WRITER"
+      ],
+      "default": "MODE_UNSPECIFIED",
+      "title": "- MODE_UNSPECIFIED: SINGLE_NODE_XXX are not supported yet\n - MULTI_NODE_SINGLE_WRITER: not supported yet"
+    },
+    "Multinode": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "nodes is the number of nodes to run job across in parallel."
+        },
+        "implementation": {
+          "type": "string",
+          "title": "implementation is the specific implementation of multinode to be used.\nThis must match the implementation used by the application within your\njob container because different multinode implementations require\nslightly different wire up configurations. Must be one of: \"ompi\",\n\"openmpi\", \"mpich\", \"gasnet\""
+        },
+        "procsPerNode": {
+          "type": "integer",
+          "format": "int64",
+          "description": "procs_per_node specifies the number of processes to spawn\nwithin each job container. If not specified, this value defaults to\nthe number of CPUs allocated to the job container. The total number\nof processes spawned for a job can be calculated by multiplying\nthis value by the number of nodes requested."
+        }
+      },
+      "description": "Multinode enables a job to run multiple containers across multiple nodes\nin parallel by leveraging various implementation for communication and\nsynchronization."
+    },
+    "NameArg": {
+      "type": "string",
+      "enum": [
+        "NAME_ARG_UNSPECIFIED",
+        "USERNAME",
+        "ORGANIZATION_ID",
+        "ACCOUNT_ID",
+        "WORKFLOW_ID",
+        "CUSTOM_NAME"
+      ],
+      "default": "NAME_ARG_UNSPECIFIED"
+    },
+    "Network": {
+      "type": "object",
+      "properties": {
+        "isolated": {
+          "type": "boolean",
+          "description": "isolated forces the use of a container network namespace.\nThis is required for reaching a job container port with port\nforwarding."
+        },
+        "exposeTcp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_tcp is a list of container TCP ports to expose."
+        },
+        "exposeUdp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_udp is a list of container UDP ports to expose."
+        }
+      },
+      "description": "Network defines if the job should be run inside its own network namespace\nand enabled optional exposure of job container ports.\nThis is required if you want to expose ports from the job container\ndirectly or via port forwarding."
+    },
+    "NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    },
+    "Organization": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "OrganizationRelationship": {
+      "type": "string",
+      "enum": [
+        "ORGANIZATION_MEMBER",
+        "ORGANIZATION_OWNER"
+      ],
+      "default": "ORGANIZATION_MEMBER"
+    },
+    "Ownership": {
+      "type": "string",
+      "enum": [
+        "OWNERSHIP_UNSPECIFIED",
+        "ROOT",
+        "USER",
+        "ACCOUNT"
+      ],
+      "default": "OWNERSHIP_UNSPECIFIED",
+      "title": "- ACCOUNT: ACCOUNT is supported with group ownership only"
+    },
+    "PendingWorkflowDetails": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "PendingWorkflowDetailsResponse": {
+      "type": "object",
+      "properties": {
+        "pendingWorkflowDetails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/PendingWorkflowDetails"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "Policy": {
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "$ref": "#/definitions/Timeout",
+          "description": "timeout specifies rules related to the duration of a workflow step."
+        },
+        "retry": {
+          "$ref": "#/definitions/Retry",
+          "description": "retry specifies rules related to rerunning a workflow step in case of\nfailure."
+        }
+      },
+      "description": "Policy contains configurable rules for the execution of a workflow step.\nThe default policy for a step will set a value for timeout if a custom one\nis not specified."
+    },
+    "Properties": {
+      "type": "object",
+      "properties": {
+        "retainOnDelete": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ProvisionDefinition": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "memory": {
+          "type": "string"
+        },
+        "cpus": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "cpuType": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "inactive": {
+          "type": "boolean"
+        },
+        "provider": {
+          "$ref": "#/definitions/ProvisionProvider"
+        },
+        "topologyZones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "networking bandwidths, not today, someday\n io/storage bandwidths, not today, someday"
+        }
+      },
+      "description": "ProvisionDefinition is the object representing a specific resource\n configuration spec that is supported by the cluster."
+    },
+    "ProvisionProvider": {
+      "type": "string",
+      "enum": [
+        "PROVISION_PROVIDER_UNSPECIFIED",
+        "PROVISION_PROVIDER_AWS",
+        "PROVISION_PROVIDER_AZURE",
+        "PROVISION_PROVIDER_DOCKER",
+        "PROVISION_PROVIDER_KUBERNETES",
+        "PROVISION_PROVIDER_VSPHERE",
+        "PROVISION_PROVIDER_GCP"
+      ],
+      "default": "PROVISION_PROVIDER_UNSPECIFIED"
+    },
+    "RenderApplicationBody": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "RenderApplicationTemplateRequest": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "RenderApplicationTemplateResponse": {
+      "type": "object",
+      "properties": {
+        "renderedWorkflow": {
+          "type": "string"
+        }
+      }
+    },
+    "Retry": {
+      "type": "object",
+      "properties": {
+        "attempts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "attempts is the number of retry attemps before failing the step\ncompletely."
+        }
+      },
+      "description": "Retry specifies rules related to rerunning a workflow step in case of\nfailure."
+    },
+    "S3Secret": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string"
+        },
+        "accessKey": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "sessionToken": {
+          "type": "string"
+        }
+      }
+    },
+    "Scope": {
+      "type": "string",
+      "enum": [
+        "SCOPE_UNSPECIFIED",
+        "ALL",
+        "USER",
+        "ACCOUNT"
+      ],
+      "default": "SCOPE_UNSPECIFIED"
+    },
+    "ScoreWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        },
+        "withChecks": {
+          "type": "boolean"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        }
+      }
+    },
+    "ScoreWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "score": {
+          "type": "number",
+          "format": "float"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Secret": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/SecretScope"
+        },
+        "type": {
+          "$ref": "#/definitions/SecretType"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        }
+      }
+    },
+    "SecretIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "SecretScope": {
+      "type": "string",
+      "enum": [
+        "SECRET_SCOPE_UNSPECIFIED",
+        "SECRET_SCOPE_USER",
+        "SECRET_SCOPE_ACCOUNT",
+        "SECRET_SCOPE_ORGANIZATION",
+        "SECRET_SCOPE_CLUSTER"
+      ],
+      "default": "SECRET_SCOPE_UNSPECIFIED"
+    },
+    "SecretType": {
+      "type": "string",
+      "enum": [
+        "SECRET_TYPE_UNSPECIFIED",
+        "SECRET_TYPE_VALUE",
+        "SECRET_TYPE_S3",
+        "SECRET_TYPE_HTTP",
+        "SECRET_TYPE_IMAGE",
+        "SECRET_TYPE_MAP",
+        "SECRET_TYPE_DECRYPTION_SIF"
+      ],
+      "default": "SECRET_TYPE_UNSPECIFIED"
+    },
+    "Secrets": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string"
+        }
+      }
+    },
+    "SelectAccountResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "SetVolumeStatusBody": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        }
+      }
+    },
+    "SetVolumeStatusResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        }
+      }
+    },
+    "StageKind": {
+      "type": "string",
+      "enum": [
+        "STAGE_KIND_UNSPECIFIED",
+        "STAGE_KIND_WORKFLOW",
+        "STAGE_KIND_JOB",
+        "STAGE_KIND_FILE",
+        "STAGE_KIND_IMAGE",
+        "STAGE_KIND_VOLUME",
+        "STAGE_KIND_COMPLETED"
+      ],
+      "default": "STAGE_KIND_UNSPECIFIED"
+    },
+    "StartWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        },
+        "rawSpecification": {
+          "type": "string"
+        }
+      }
+    },
+    "Status": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Any"
+          }
+        }
+      }
+    },
+    "StorageClassDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "mount": {
+          "$ref": "#/definitions/StorageClassDefinition.Mount"
+        },
+        "access": {
+          "$ref": "#/definitions/Access"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "secrets": {
+          "$ref": "#/definitions/Secrets"
+        },
+        "properties": {
+          "$ref": "#/definitions/Properties"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        },
+        "scope": {
+          "$ref": "#/definitions/Scope"
+        },
+        "capacity": {
+          "$ref": "#/definitions/Capacity"
+        },
+        "affinities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Affinity"
+          }
+        },
+        "volumes": {
+          "$ref": "#/definitions/Volumes"
+        },
+        "restricted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "StorageClassDefinition.Mount": {
+      "type": "object",
+      "properties": {
+        "filesystem": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "group": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "permissions": {
+          "type": "string"
+        }
+      }
+    },
+    "StorageClassInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "driverId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "class": {
+          "$ref": "#/definitions/StorageClassDefinition"
+        },
+        "scope": {
+          "$ref": "#/definitions/Scope"
+        },
+        "status": {
+          "$ref": "#/definitions/StorageClassStatus"
+        },
+        "restricted": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        },
+        "retain": {
+          "type": "boolean"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "StorageClassStatus": {
+      "type": "string",
+      "enum": [
+        "STORAGE_CLASS_STATUS_UNSPECIFIED",
+        "STORAGE_CLASS_STATUS_NOT_READY",
+        "STORAGE_CLASS_STATUS_READY",
+        "STORAGE_CLASS_STATUS_DISABLED",
+        "STORAGE_CLASS_STATUS_ERROR"
+      ],
+      "default": "STORAGE_CLASS_STATUS_UNSPECIFIED"
+    },
+    "SummarizedWorkflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "runningStages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        }
+      }
+    },
+    "SummarizedWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/SummarizedWorkflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "SupportedTemplateValues": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "TaskArray": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "format": "int64",
+          "description": "start is the start of the range for Task ID values. Inclusive."
+        },
+        "end": {
+          "type": "integer",
+          "format": "int64",
+          "description": "end is the end of the Task ID values. Inclusive."
+        },
+        "concurrency": {
+          "type": "integer",
+          "format": "int64",
+          "description": "concurrency is a limit on the number of tasks that can be run in\nparallel. The max concurrency for a workflow job is 200."
+        }
+      },
+      "description": "TaskArray allows a job to be broken up in an embarrassingly parallel\nmanner for more effective execution. TaskArray jobs are automatically\npopulated with a `FB_TASK_ID` environment variable to indicate the index\nwithin the task array range of the currently executing task to the\napplication."
+    },
+    "TemplateValues": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "stringValue": {
+          "type": "string"
+        },
+        "uintValue": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "boolValue": {
+          "type": "boolean"
+        }
+      }
+    },
+    "TerminalSize": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "cols": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "x": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "y": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Timeout": {
+      "type": "object",
+      "properties": {
+        "execute": {
+          "type": "string",
+          "description": "execute  is the maximum allowed duration of a workflow step to run\nbefore it is failed."
+        }
+      },
+      "description": "Timeout specifies rules related to the duration of a workflow step."
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "uri is the uri of the resource to be accessed."
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "secrets is a map of key value pairs to use to access resource.\nThe key specifies the type of data that is being used and the value\nspecifies raw data or a template for the workflow system to populate with\ndata internally from the secrets engine."
+        },
+        "secret": {
+          "type": "string"
+        },
+        "decryptionSecret": {
+          "type": "string"
+        }
+      },
+      "description": "URI contains the specification for a resource to access as well as\nadditional data necessary for access such as credentials."
+    },
+    "Unit": {
+      "type": "string",
+      "enum": [
+        "UNIT_UNSPECIFIED",
+        "MIB",
+        "GIB",
+        "TIB",
+        "PIB",
+        "EIB"
+      ],
+      "default": "UNIT_UNSPECIFIED"
+    },
+    "UpdateAccountBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/AccountRelationship"
+        }
+      }
+    },
+    "UpdateApplicationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateOrganizationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateOrganizationSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        }
+      }
+    },
+    "UpdateSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        }
+      }
+    },
+    "UpdateUserAccountResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateUserProfileAvatarRequest": {
+      "type": "object",
+      "properties": {
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "UpdateUserProfileRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateUserProfileSettingsRequest": {
+      "type": "object",
+      "properties": {
+        "settings": {
+          "type": "object"
+        }
+      },
+      "description": "TODO: given this is more of a backend support item we may want to remove this from the public api."
+    },
+    "UpdateVolumeBody": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/VolumeDefinition"
+        }
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "UserListResponse": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/User"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "UserProfile": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "organizationId": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        },
+        "settings": {
+          "type": "object"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ValidateWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        }
+      }
+    },
+    "ValidateWorkflowResponse": {
+      "type": "object"
+    },
+    "ValueSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "VersionGetResponse": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "Volume": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the key value of the volume in the volume map containing this\nstruct. This is normally set internally by client side code when parsing\nworkflow DSLs, but will need to be set when calling the API directly."
+        },
+        "type": {
+          "type": "string",
+          "title": "type is the kind of volume. This currently determines the lifetime of the\nvolume and the data contained within it.\nEphemeral volumes are empty upon creation and have a lifespan of the\nworkflow duration. Upon workflow completion the volume and its data are\ndeleted. Host volumes represent directories on the shared filesystems of\nthe nodes themselves. They must be pre-existing and fall under\ndirectories specified in the shared-fs-roots config property of the\nVolume service. Must be one of \"EPHEMERAL\" or \"HOST\".\nDeprecated in favor of reference"
+        },
+        "ingress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/File"
+          },
+          "description": "Ingress specifies data that should be fetched and made available within\nthe volume."
+        },
+        "egress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/File"
+          },
+          "description": "Egress specifies data that exists within the volume that should be\nexported to another storage location."
+        },
+        "path": {
+          "type": "string",
+          "title": "Path is specified for host volume types with the absolute path to the\ndirectory to mount.\nDeprecated: will be removed"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Volume reference this volume is referring to."
+        }
+      },
+      "description": "Volume is an instance of a data volume used within the scope of a workflow.\nThere are a couple different types of volumes that have different data\nretention behavior. Volumes are the means of managing data for compute\napplications to process over the course of a workflow and orchestrate\ndata movement to bring injest data into the bounds of a workflow for\ncomputation or export data generated from computation it to other storage\nlocations.\n\nTODO(cedric): deprecate type/path fields\n reserved 2, 5;\n reserved \"type\", \"path\";"
+    },
+    "VolumeDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "accessTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeStatus": {
+      "type": "string",
+      "enum": [
+        "VOLUME_STATUS_UNSPECIFIED",
+        "VOLUME_STATUS_ENABLED",
+        "VOLUME_STATUS_DISABLED"
+      ],
+      "default": "VOLUME_STATUS_UNSPECIFIED"
+    },
+    "Volumes": {
+      "type": "object",
+      "properties": {
+        "nameArgs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NameArg"
+          }
+        },
+        "nameFormat": {
+          "type": "string"
+        },
+        "maxByAccount": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Workflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "rawSpecification": {
+          "type": "string"
+        }
+      }
+    },
+    "WorkflowDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "version defines the version of the workflow document."
+        },
+        "volumes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Volume"
+          },
+          "description": "volumes is a map defining volumes to use for this workflow by name.\nMap keys define the name of the volume and values are specifications\ndetailing the data volume. Volume names are used by different\ncomponents of the workflow to reference a particular volume instance."
+        },
+        "jobs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowDefinition.Job"
+          },
+          "description": "jobs is a map defining jobs to run as a part of the workflow.\nMap keys define the name of the job and values are specifications\ndetailing the compute job. Job names are used by different components\nof the workflow to reference a particular compute job instance."
+        },
+        "completed": {
+          "$ref": "#/definitions/Completed",
+          "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Annotations for the whole workflow. Currently, this is used by the\nscheduler to place jobs in a certain topology zone"
+        },
+        "defaults": {
+          "$ref": "#/definitions/Defaults"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "files is a map defining files that may be injected into volumes and jobs.\nMap keys define the name of the file and values are the file's contents.\nFiles names are used by job and volume.ingress components\nto reference a specific file."
+        }
+      },
+      "description": "WorkflowDefinition is the highest level unit of work for a Fuzzball cluster.\nWorkflows consist of orchestrating data volumes, container images and\ncontainer execution across a compute cluster."
+    },
+    "WorkflowDefinition.Job": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Used internally to store the job name.  If this field is present in a\ndefinition then it will be ignored in preference for the map key used in\nthe `jobs` field."
+        },
+        "image": {
+          "$ref": "#/definitions/URI",
+          "title": "Image is the URI to the container image to be used for this job.\nSupported uri formats are: \"docker://...\" and \"oras://\" for OCI\nand SIF(Singularity Image Format) images respectively.\nE.g. docker://alpine:latest"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "command is the arguments executed by the container process."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside of the job\ncontainer."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowDefinition.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "cwd allows the specification of the the working dirctory used by the job.\nThis must be an absolute path. If unset the working directory defaults\nfirst to the working directory in the OCI image config if present and\nthen to \"/\"."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "requires is a list of prerequisite jobs in the workflow that must be\ncompleted before this job may be started. This allows jobs within a\nworkflow to be formed into a directed asyclic graph. If requirements\nspecified by different jobs results in a cycle, the workflow will fail to\nstart."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        },
+        "multinode": {
+          "$ref": "#/definitions/Multinode",
+          "description": "multinode enables a job to run across multiple nodes in parallel."
+        },
+        "taskArray": {
+          "$ref": "#/definitions/TaskArray",
+          "description": "task_array enables a job to be broken up into multiple tasks that run\nconcurrently. This is useful for doing embarassingly parallel compute\nwork."
+        },
+        "network": {
+          "$ref": "#/definitions/Network",
+          "title": "network defines if the job should run inside its own netowrk namespace"
+        },
+        "script": {
+          "type": "string",
+          "title": "shellbang script executed via command"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "args passed to above script field, can also be passed to existing command"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Job is a single compute \"step\" in a workflow.\nThere are a variety of different types of jobs that\nresult in one or more containers being spawned.\nBy default, a single container is spawned unless the\nTaskArray or Multinode fields are specified."
+    },
+    "WorkflowDefinition.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "WorkflowDefinition.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "WorkflowDefinition.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "WorkflowDefinition.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "WorkflowGatewayAttachRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "stdin": {
+          "type": "boolean"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "ws": {
+          "$ref": "#/definitions/TerminalSize"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "WorkflowGatewayAttachResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowGatewayExecRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ws": {
+          "$ref": "#/definitions/TerminalSize"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "terminal": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "WorkflowGatewayExecResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        },
+        "exitCode": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowGatewayLogCommand": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+      ],
+      "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+    },
+    "WorkflowGatewayLogResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowGatewayLogShow": {
+      "type": "object",
+      "properties": {
+        "tail": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "follow": {
+          "type": "boolean"
+        }
+      }
+    },
+    "WorkflowGatewayPortForwardResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "WorkflowPlan": {
+      "type": "object",
+      "properties": {
+        "stages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        }
+      }
+    },
+    "WorkflowSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/ImageDecryptionSecret"
+        }
+      }
+    },
+    "WorkflowSecretsMap": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowSecret"
+          }
+        }
+      }
+    },
+    "WorkflowStage": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "kind": {
+          "$ref": "#/definitions/StageKind"
+        },
+        "error": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "details": {
+          "type": "object"
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowStatus": {
+      "type": "string",
+      "enum": [
+        "STAGE_STATUS_UNSPECIFIED",
+        "STAGE_STATUS_STARTED",
+        "STAGE_STATUS_FINISHED",
+        "STAGE_STATUS_FAILED",
+        "STAGE_STATUS_CANCELED"
+      ],
+      "default": "STAGE_STATUS_UNSPECIFIED",
+      "title": "- STAGE_STATUS_UNSPECIFIED: also used for pending"
+    }
+  }
+}

--- a/code-generation/schemas/fuzzball-v2.2-openapi.json
+++ b/code-generation/schemas/fuzzball-v2.2-openapi.json
@@ -1,0 +1,6335 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Fuzzball API",
+    "version": "2.0",
+    "contact": {
+      "name": "CtrlIQ, Inc",
+      "url": "https://ciq.co",
+      "email": "info@ciq.co"
+    }
+  },
+  "tags": [
+    {
+      "name": "AccountService"
+    },
+    {
+      "name": "ApplicationService"
+    },
+    {
+      "name": "ClusterService"
+    },
+    {
+      "name": "OrganizationService"
+    },
+    {
+      "name": "ProvisionService"
+    },
+    {
+      "name": "SecretService"
+    },
+    {
+      "name": "StorageClassService"
+    },
+    {
+      "name": "StorageVolumeService"
+    },
+    {
+      "name": "UserService"
+    },
+    {
+      "name": "VersionService"
+    },
+    {
+      "name": "WorkflowService"
+    },
+    {
+      "name": "WorkflowGatewayService"
+    },
+    {
+      "name": "WorkflowGenerateService"
+    }
+  ],
+  "basePath": "/v2",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/accounts": {
+      "get": {
+        "operationId": "ListAccounts",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListAccountsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "showUserAccounts",
+            "description": "only valid for org/platform owners, by default all users/owners will only\nsee their own user account",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateAccountRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/update-user-account": {
+      "get": {
+        "operationId": "UpdateUserAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UpdateUserAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}": {
+      "get": {
+        "operationId": "GetAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members": {
+      "get": {
+        "operationId": "ListAccountMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "ACCOUNT_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "AddAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members/{userId}": {
+      "delete": {
+        "operationId": "RemoveAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "ACCOUNT_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/token": {
+      "get": {
+        "operationId": "SelectAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SelectAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/applications": {
+      "get": {
+        "operationId": "ListApplications",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListApplicationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/categories": {
+      "get": {
+        "operationId": "ListApplicationCategories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListApplicationCategoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "operationId": "GetApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:bundle": {
+      "get": {
+        "operationId": "GetApplicationBundle",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetApplicationBundleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "excludedParts",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "TEMPLATE",
+                "VALUES",
+                "METADATA"
+              ]
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:disable": {
+      "put": {
+        "operationId": "DisableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:enable": {
+      "put": {
+        "operationId": "EnableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:render": {
+      "post": {
+        "operationId": "RenderApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:upsert": {
+      "patch": {
+        "operationId": "UpsertApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpsertApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:copy": {
+      "post": {
+        "operationId": "CopyApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CopyApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:render": {
+      "post": {
+        "operationId": "RenderApplicationTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:start": {
+      "post": {
+        "operationId": "StartApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StartApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories": {
+      "get": {
+        "operationId": "ListCatalogRepositories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListCatalogRepositoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "AddCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddCatalogRepositoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories/{id}": {
+      "get": {
+        "operationId": "GetCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CatalogRepositorySummary"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateCatalogRepositoryBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories/{id}:reload": {
+      "post": {
+        "operationId": "ReloadCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ReloadCatalogRepositoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReloadCatalogRepositoryBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories:import": {
+      "post": {
+        "operationId": "ImportCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ImportCatalogRepositoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ImportCatalogRepositoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/sync:updateSchedule": {
+      "post": {
+        "operationId": "ScheduleCatalogSync",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ScheduleCatalogSyncRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/cluster/{id}": {
+      "get": {
+        "operationId": "GetCluster",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/clusters": {
+      "get": {
+        "operationId": "ListClusters",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListClustersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/organization": {
+      "get": {
+        "operationId": "GetOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrganizationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members": {
+      "get": {
+        "operationId": "ListOrganizationMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "post": {
+        "operationId": "AddOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddOrganizationMemberRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members/{id}": {
+      "delete": {
+        "operationId": "RemoveOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/secrets": {
+      "get": {
+        "operationId": "ListOrganizationSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/organization/secrets/{id}": {
+      "get": {
+        "operationId": "GetOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrganizationSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/profile": {
+      "get": {
+        "operationId": "GetUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "UserService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/avatar": {
+      "patch": {
+        "operationId": "UpdateUserProfileAvatar",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileAvatarRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/settings": {
+      "patch": {
+        "summary": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+        "operationId": "UpdateUserProfileSettings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileSettingsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/provision/definitions": {
+      "get": {
+        "operationId": "ListProvisionDefinitions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListProvisionDefinitionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "inactive",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionService"
+        ]
+      }
+    },
+    "/provision/definitions/{id}": {
+      "get": {
+        "operationId": "GetProvisionDefinition",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisionDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionService"
+        ]
+      }
+    },
+    "/secrets": {
+      "get": {
+        "operationId": "ListSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/secrets/{id}": {
+      "get": {
+        "operationId": "GetSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/storage-classes": {
+      "get": {
+        "operationId": "ListStorageClasses",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListStorageClassesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/storage-classes/{id}": {
+      "get": {
+        "operationId": "GetStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/StorageClassInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/stream/workflow/attach": {
+      "post": {
+        "operationId": "WorkflowGatewayAttach",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayAttachResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayAttachResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowGatewayAttachRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/exec": {
+      "post": {
+        "operationId": "WorkflowGatewayExec",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayExecResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayExecResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowGatewayExecRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/generate": {
+      "post": {
+        "operationId": "GenerateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/GenerateWorkflowServerMessage"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of GenerateWorkflowServerMessage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GenerateWorkflowClientMessage"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGenerateService"
+        ]
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Get the fuzzball agent version",
+        "operationId": "VersionGet",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VersionGetResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "VersionService"
+        ]
+      }
+    },
+    "/volumes": {
+      "get": {
+        "operationId": "ListVolumes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListVolumesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateVolumeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}": {
+      "get": {
+        "operationId": "GetVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateVolumeBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}:set-status": {
+      "patch": {
+        "operationId": "SetVolumeStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SetVolumeStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetVolumeStatusBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/workflows": {
+      "get": {
+        "summary": "List workflows",
+        "operationId": "ListWorkflows",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListWorkflowsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "status",
+            "description": "Deprecated as this was not used and we need ability to filter by multiple statuses.\n\n - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "requestedStatuses",
+            "description": "Allows multiple statuses to be requested.\n\n - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "STAGE_STATUS_UNSPECIFIED",
+                "STAGE_STATUS_STARTED",
+                "STAGE_STATUS_FINISHED",
+                "STAGE_STATUS_FAILED",
+                "STAGE_STATUS_CANCELED"
+              ]
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "scope",
+            "description": " - SCOPE_USER: Only return workflows for the user for the currently selected account\n - SCOPE_ACCOUNT: Return workflows for the account",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SCOPE_UNSPECIFIED",
+              "SCOPE_USER",
+              "SCOPE_ACCOUNT"
+            ],
+            "default": "SCOPE_UNSPECIFIED"
+          },
+          {
+            "name": "aipFilter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "summary": "Start a new workflow",
+        "operationId": "StartWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StartWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary": {
+      "get": {
+        "summary": "Get a summary of workflows",
+        "operationId": "GetWorkflowsSummary",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkflowsSummaryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "userWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "otherOwnerWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary/account-owner/details": {
+      "get": {
+        "summary": "Get workflow summary details",
+        "operationId": "GetAccountOwnerWorkflowsSummaryDetails",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetAccountOwnerWorkflowsSummaryDetailsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "requestedStatus",
+            "description": " - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary/account-owner/users": {
+      "get": {
+        "summary": "Account owners request workflows in some state.",
+        "operationId": "GetAccountOwnerWorkflowsUsers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetAccountOwnerWorkflowsUsersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "requestedStatus",
+            "description": " - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}": {
+      "get": {
+        "summary": "Get details on a workflow",
+        "operationId": "GetWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Workflow"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners": {
+      "get": {
+        "operationId": "ListWorkflowOwners",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "operationId": "AddWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddWorkflowOwnerBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners/{userId}": {
+      "delete": {
+        "operationId": "RemoveWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:log": {
+      "get": {
+        "operationId": "WorkflowGatewayLog",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayLogResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayLogResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "show.tail",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "show.follow",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "command",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+            ],
+            "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+          },
+          {
+            "name": "name",
+            "description": "Name of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "rank",
+            "description": "Rank of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/workflows/{id}:status": {
+      "get": {
+        "summary": "Get the status on a workflow",
+        "operationId": "GetWorkflowStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkflowStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:stop": {
+      "patch": {
+        "summary": "Stop a workflow",
+        "operationId": "StopWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:score": {
+      "patch": {
+        "summary": "ScoreWorkflow returns the score for a workflow definition.",
+        "operationId": "ScoreWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ScoreWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ScoreWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:validate": {
+      "post": {
+        "summary": "Validate a workflow definition",
+        "operationId": "ValidateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ValidateWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Access": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Access.Type"
+        },
+        "mode": {
+          "$ref": "#/definitions/Mode"
+        }
+      }
+    },
+    "Access.Type": {
+      "type": "string",
+      "enum": [
+        "TYPE_UNSPECIFIED",
+        "FILESYSTEM",
+        "BLOCK"
+      ],
+      "default": "TYPE_UNSPECIFIED",
+      "title": "- BLOCK: BLOCK is not supported yet"
+    },
+    "Account": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "AccountOwnerWorkflowsSummary": {
+      "type": "object",
+      "properties": {
+        "currentWorkflowsStarted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentWorkflowsPending": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "averageWorkflowPendingMilliseconds": {
+          "type": "number",
+          "format": "double"
+        },
+        "workflowsCompleted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "totalAccountUsers": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "AccountOwnerWorkflowsSummaryDetails": {
+      "type": "object",
+      "properties": {
+        "workflowsResponse": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        }
+      }
+    },
+    "AccountRelationship": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT_MEMBER",
+        "ACCOUNT_OWNER"
+      ],
+      "default": "ACCOUNT_MEMBER"
+    },
+    "AddAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/AccountRelationship"
+        }
+      }
+    },
+    "AddCatalogRepositoryRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        }
+      }
+    },
+    "AddOrganizationMemberRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/OrganizationRelationship"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "AddWorkflowOwnerBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        }
+      }
+    },
+    "Affinity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Affinity.Type"
+        },
+        "key": {
+          "type": "string"
+        },
+        "filter": {
+          "type": "string"
+        }
+      }
+    },
+    "Affinity.Type": {
+      "type": "string",
+      "enum": [
+        "AFFINITY_UNSPECIFIED",
+        "ANNOTATION",
+        "RESOURCE"
+      ],
+      "default": "AFFINITY_UNSPECIFIED"
+    },
+    "Any": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "Application": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "templateSha": {
+          "type": "string"
+        },
+        "supportedValueSha": {
+          "type": "string"
+        },
+        "createdBy": {
+          "type": "string"
+        },
+        "createdByEmail": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationBundlePart": {
+      "type": "string",
+      "enum": [
+        "TEMPLATE",
+        "VALUES",
+        "METADATA"
+      ],
+      "default": "TEMPLATE"
+    },
+    "ApplicationCategory": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationMetadata": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationOwnerKind": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT",
+        "ORGANIZATION",
+        "PROVIDER"
+      ],
+      "default": "ACCOUNT",
+      "title": "- ACCOUNT: default\n - ORGANIZATION: must be an organization owner to use\n - PROVIDER: only available via direct sql updates (for now)"
+    },
+    "Capability": {
+      "type": "string",
+      "enum": [
+        "CAPABILITY_UNSPECIFIED",
+        "SELINUX"
+      ],
+      "default": "CAPABILITY_UNSPECIFIED"
+    },
+    "Capacity": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "unit": {
+          "$ref": "#/definitions/Unit"
+        }
+      }
+    },
+    "CatalogRepository": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "CatalogRepositorySummary": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "Cluster": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/ClusterKind"
+        },
+        "status": {
+          "$ref": "#/definitions/ClusterStatus"
+        },
+        "apiEndpoint": {
+          "type": "string"
+        },
+        "openapiEndpoint": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "ClusterKind": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_KIND_UNSPECIFIED",
+        "CLUSTER_KIND_ORCHESTRATE",
+        "CLUSTER_KIND_FEDERATE"
+      ],
+      "default": "CLUSTER_KIND_UNSPECIFIED"
+    },
+    "ClusterStatus": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_STATUS_UNSPECIFIED",
+        "CLUSTER_STATUS_UNSYNCED",
+        "CLUSTER_STATUS_SYNCING",
+        "CLUSTER_STATUS_READY",
+        "CLUSTER_STATUS_UNREACHABLE",
+        "CLUSTER_STATUS_ERROR",
+        "CLUSTER_STATUS_DISABLED"
+      ],
+      "default": "CLUSTER_STATUS_UNSPECIFIED"
+    },
+    "Completed": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      },
+      "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+    },
+    "CopyApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        }
+      }
+    },
+    "CreateAccountRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "CreateApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string",
+          "title": "if not provided a default will be set"
+        }
+      }
+    },
+    "CreateSecretRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/SecretScope"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        },
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/ImageDecryptionSecret"
+        }
+      }
+    },
+    "CreateVolumeRequest": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/VolumeDefinition"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "Defaults": {
+      "type": "object",
+      "properties": {
+        "job": {
+          "$ref": "#/definitions/Defaults.Job"
+        }
+      },
+      "description": "Default defines the default settings that should be applied to all jobs in the workflow.\nThese can be overridden at the job level."
+    },
+    "Defaults.Job": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside all job\ncontainers.  Will be overridden by job level env variables."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Defaults.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/Defaults.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        }
+      }
+    },
+    "Defaults.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "Defaults.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/Defaults.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/Defaults.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "Defaults.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "Defaults.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "Export": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW",
+        "ACCOUNT",
+        "CLUSTER",
+        "PUBLIC"
+      ],
+      "default": "WORKFLOW"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/URI",
+          "description": "Source is the origin of the data. The type of URIs supported are\ndetermined by whether this is specified under ingress or egress."
+        },
+        "destination": {
+          "$ref": "#/definitions/URI",
+          "description": "Destination is the location to move the data. The type of URIs\nsupported are determined by whether this is specified under ingress or\negress."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a data transfer such as max execution time and retries on\nfailure."
+        }
+      },
+      "description": "File specifies details of workflow volume data movement."
+    },
+    "GenerateWorkflowClientMessage": {
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "GenerateWorkflowServerMessage": {
+      "type": "object",
+      "properties": {
+        "workflowYaml": {
+          "type": "string"
+        },
+        "response": {
+          "type": "string"
+        }
+      }
+    },
+    "GetAccountOwnerWorkflowsSummaryDetailsResponse": {
+      "type": "object",
+      "properties": {
+        "accountOwnerWorkflowsSummaryDetails": {
+          "$ref": "#/definitions/AccountOwnerWorkflowsSummaryDetails"
+        }
+      }
+    },
+    "GetAccountOwnerWorkflowsUsersResponse": {
+      "type": "object",
+      "properties": {
+        "workflowEmails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GetApplicationBundleResponse": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        },
+        "values": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "string"
+        }
+      }
+    },
+    "GetWorkflowStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/WorkflowPlan"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "workflowStatus": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "GetWorkflowsSummaryResponse": {
+      "type": "object",
+      "properties": {
+        "userWorkflows": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        },
+        "otherOwnerWorkflows": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        },
+        "accountOwnerWorkflowsSummary": {
+          "$ref": "#/definitions/AccountOwnerWorkflowsSummary"
+        }
+      }
+    },
+    "HTTPSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "HTTPSecretInfo": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageDecryptionSecret": {
+      "type": "object",
+      "properties": {
+        "passphrase": {
+          "type": "string"
+        },
+        "pem": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageSecretInfo": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "ImportCatalogRepositoryRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        }
+      }
+    },
+    "ImportCatalogRepositoryResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "Job.Multinode": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "nodes is the number of nodes to run job across in parallel."
+        },
+        "implementation": {
+          "type": "string",
+          "title": "implementation is the specific implementation of multinode to be used.\nThis must match the implementation used by the application within your\njob container because different multinode implementations require\nslightly different wire up configurations. Must be one of: \"ompi\",\n\"openmpi\", \"mpich\", \"gasnet\""
+        },
+        "procsPerNode": {
+          "type": "integer",
+          "format": "int64",
+          "description": "procs_per_node specifies the number of processes to spawn\nwithin each job container. If not specified, this value defaults to\nthe number of CPUs allocated to the job container. The total number\nof processes spawned for a job can be calculated by multiplying\nthis value by the number of nodes requested."
+        }
+      },
+      "description": "Multinode enables a job to run multiple containers across multiple nodes\nin parallel by leveraging various implementation for communication and\nsynchronization."
+    },
+    "Job.Network": {
+      "type": "object",
+      "properties": {
+        "isolated": {
+          "type": "boolean",
+          "description": "isolated forces the use of a container network namespace.\nThis is required for reaching a job container port with port\nforwarding."
+        },
+        "exposeTcp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_tcp is a list of container TCP ports to expose."
+        },
+        "exposeUdp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_udp is a list of container UDP ports to expose."
+        }
+      },
+      "description": "Network defines if the job should be run inside its own network namespace\nand enabled optional exposure of job container ports.\nThis is required if you want to expose ports from the job container\ndirectly or via port forwarding."
+    },
+    "Job.TaskArray": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "format": "int64",
+          "description": "start is the start of the range for Task ID values. Inclusive."
+        },
+        "end": {
+          "type": "integer",
+          "format": "int64",
+          "description": "end is the end of the Task ID values. Inclusive."
+        },
+        "concurrency": {
+          "type": "integer",
+          "format": "int64",
+          "description": "concurrency is a limit on the number of tasks that can be run in\nparallel. The max concurrency for a workflow job is 200."
+        }
+      },
+      "description": "TaskArray allows a job to be broken up in an embarrassingly parallel\nmanner for more effective execution. TaskArray jobs are automatically\npopulated with a `FB_TASK_ID` environment variable to indicate the index\nwithin the task array range of the currently executing task to the\napplication."
+    },
+    "ListAccountsResponse": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Account"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListApplicationCategoriesResponse": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ApplicationCategory"
+          }
+        }
+      }
+    },
+    "ListApplicationsResponse": {
+      "type": "object",
+      "properties": {
+        "applications": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ApplicationMetadata"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListCatalogRepositoriesResponse": {
+      "type": "object",
+      "properties": {
+        "repositories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/CatalogRepositorySummary"
+          }
+        }
+      }
+    },
+    "ListClustersResponse": {
+      "type": "object",
+      "properties": {
+        "clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Cluster"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListProvisionDefinitionsResponse": {
+      "type": "object",
+      "properties": {
+        "definitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ProvisionDefinition"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListSecretsResponse": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Secret"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListStorageClassesResponse": {
+      "type": "object",
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/StorageClassInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListVolumesResponse": {
+      "type": "object",
+      "properties": {
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/VolumeInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListWorkflowsResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Workflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListWorkflowsScope": {
+      "type": "string",
+      "enum": [
+        "SCOPE_UNSPECIFIED",
+        "SCOPE_USER",
+        "SCOPE_ACCOUNT"
+      ],
+      "default": "SCOPE_UNSPECIFIED",
+      "title": "- SCOPE_USER: Only return workflows for the user for the currently selected account\n - SCOPE_ACCOUNT: Return workflows for the account"
+    },
+    "MapSecret": {
+      "type": "object",
+      "properties": {
+        "map": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Mode": {
+      "type": "string",
+      "enum": [
+        "MODE_UNSPECIFIED",
+        "SINGLE_NODE_WRITER",
+        "SINGLE_NODE_READER_ONLY",
+        "MULTI_NODE_READER_ONLY",
+        "MULTI_NODE_SINGLE_WRITER",
+        "MULTI_NODE_MULTI_WRITER",
+        "SINGLE_NODE_SINGLE_WRITER",
+        "SINGLE_NODE_MULTI_WRITER"
+      ],
+      "default": "MODE_UNSPECIFIED",
+      "title": "- MODE_UNSPECIFIED: SINGLE_NODE_XXX are not supported yet\n - MULTI_NODE_SINGLE_WRITER: not supported yet"
+    },
+    "NameArg": {
+      "type": "string",
+      "enum": [
+        "NAME_ARG_UNSPECIFIED",
+        "USERNAME",
+        "ORGANIZATION_ID",
+        "ACCOUNT_ID",
+        "WORKFLOW_ID",
+        "CUSTOM_NAME"
+      ],
+      "default": "NAME_ARG_UNSPECIFIED"
+    },
+    "NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    },
+    "OptionsInput": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "list of options for the input"
+        }
+      }
+    },
+    "Organization": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "OrganizationRelationship": {
+      "type": "string",
+      "enum": [
+        "ORGANIZATION_MEMBER",
+        "ORGANIZATION_OWNER"
+      ],
+      "default": "ORGANIZATION_MEMBER"
+    },
+    "Ownership": {
+      "type": "string",
+      "enum": [
+        "OWNERSHIP_UNSPECIFIED",
+        "ROOT",
+        "USER",
+        "ACCOUNT"
+      ],
+      "default": "OWNERSHIP_UNSPECIFIED",
+      "title": "- ACCOUNT: ACCOUNT is supported with group ownership only"
+    },
+    "Policy": {
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "$ref": "#/definitions/Timeout",
+          "description": "timeout specifies rules related to the duration of a workflow step."
+        },
+        "retry": {
+          "$ref": "#/definitions/Retry",
+          "description": "retry specifies rules related to rerunning a workflow step in case of\nfailure."
+        }
+      },
+      "description": "Policy contains configurable rules for the execution of a workflow step.\nThe default policy for a step will set a value for timeout if a custom one\nis not specified."
+    },
+    "Port": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "export": {
+          "$ref": "#/definitions/Export"
+        }
+      }
+    },
+    "Properties": {
+      "type": "object",
+      "properties": {
+        "retainOnDelete": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ProvisionDefinition": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "memory": {
+          "type": "string"
+        },
+        "cpus": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "cpuType": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "inactive": {
+          "type": "boolean"
+        },
+        "provider": {
+          "$ref": "#/definitions/ProvisionProvider"
+        },
+        "topologyZones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "networking bandwidths, not today, someday\n io/storage bandwidths, not today, someday"
+        }
+      },
+      "description": "ProvisionDefinition is the object representing a specific resource\n configuration spec that is supported by the cluster."
+    },
+    "ProvisionProvider": {
+      "type": "string",
+      "enum": [
+        "PROVISION_PROVIDER_UNSPECIFIED",
+        "PROVISION_PROVIDER_AWS",
+        "PROVISION_PROVIDER_AZURE",
+        "PROVISION_PROVIDER_DOCKER",
+        "PROVISION_PROVIDER_KUBERNETES",
+        "PROVISION_PROVIDER_VSPHERE",
+        "PROVISION_PROVIDER_GCP"
+      ],
+      "default": "PROVISION_PROVIDER_UNSPECIFIED"
+    },
+    "Proxy": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "ReloadCatalogRepositoryBody": {
+      "type": "object"
+    },
+    "ReloadCatalogRepositoryResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "RenderApplicationBody": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "RenderApplicationTemplateRequest": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "RenderApplicationTemplateResponse": {
+      "type": "object",
+      "properties": {
+        "renderedWorkflow": {
+          "type": "string"
+        }
+      }
+    },
+    "Retry": {
+      "type": "object",
+      "properties": {
+        "attempts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "attempts is the number of retry attemps before failing the step\ncompletely."
+        }
+      },
+      "description": "Retry specifies rules related to rerunning a workflow step in case of\nfailure."
+    },
+    "S3Secret": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string"
+        },
+        "accessKey": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "sessionToken": {
+          "type": "string"
+        }
+      }
+    },
+    "S3SecretInfo": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      },
+      "title": "Non-sensitive information about secrets"
+    },
+    "ScheduleCatalogSyncRequest": {
+      "type": "object",
+      "properties": {
+        "cron": {
+          "type": "string"
+        },
+        "suspend": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Scope": {
+      "type": "string",
+      "enum": [
+        "SCOPE_UNSPECIFIED",
+        "ALL",
+        "USER",
+        "ACCOUNT"
+      ],
+      "default": "SCOPE_UNSPECIFIED"
+    },
+    "ScoreWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        },
+        "withChecks": {
+          "type": "boolean"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        }
+      }
+    },
+    "ScoreWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "score": {
+          "type": "number",
+          "format": "float"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Secret": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/SecretScope"
+        },
+        "type": {
+          "$ref": "#/definitions/SecretType"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3SecretInfo"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecretInfo"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecretInfo"
+        }
+      }
+    },
+    "SecretIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "SecretScope": {
+      "type": "string",
+      "enum": [
+        "SECRET_SCOPE_UNSPECIFIED",
+        "SECRET_SCOPE_USER",
+        "SECRET_SCOPE_ACCOUNT",
+        "SECRET_SCOPE_ORGANIZATION",
+        "SECRET_SCOPE_CLUSTER"
+      ],
+      "default": "SECRET_SCOPE_UNSPECIFIED"
+    },
+    "SecretTemplateValue": {
+      "type": "object",
+      "properties": {
+        "reference": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/SecretType"
+        }
+      }
+    },
+    "SecretType": {
+      "type": "string",
+      "enum": [
+        "SECRET_TYPE_UNSPECIFIED",
+        "SECRET_TYPE_VALUE",
+        "SECRET_TYPE_S3",
+        "SECRET_TYPE_HTTP",
+        "SECRET_TYPE_IMAGE",
+        "SECRET_TYPE_MAP",
+        "SECRET_TYPE_DECRYPTION_SIF",
+        "UNSPECIFIED",
+        "VALUE",
+        "S3",
+        "HTTP",
+        "IMAGE",
+        "MAP",
+        "DECRYPTION_SIF"
+      ],
+      "default": "SECRET_TYPE_UNSPECIFIED"
+    },
+    "Secrets": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string"
+        }
+      }
+    },
+    "SelectAccountResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "Service": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Used internally to store the job name.  If this field is present in a\ndefinition then it will be ignored in preference for the map key used in\nthe `jobs` field."
+        },
+        "image": {
+          "$ref": "#/definitions/URI",
+          "title": "Image is the URI to the container image to be used for this job.\nSupported uri formats are: \"docker://...\" and \"oras://\" for OCI\nand SIF(Singularity Image Format) images respectively.\nE.g. docker://alpine:latest"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "command is the arguments executed by the container process."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside of the job\ncontainer."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Service.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "cwd allows the specification of the the working dirctory used by the job.\nThis must be an absolute path. If unset the working directory defaults\nfirst to the working directory in the OCI image config if present and\nthen to \"/\"."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "requires is a list of prerequisite jobs in the workflow that must be\ncompleted before this job may be started. This allows jobs within a\nworkflow to be formed into a directed asyclic graph. If requirements\nspecified by different jobs results in a cycle, the workflow will fail to\nstart."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/Service.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        },
+        "multinode": {
+          "$ref": "#/definitions/Service.Multinode",
+          "description": "multinode enables a job to run across multiple nodes in parallel."
+        },
+        "taskArray": {
+          "$ref": "#/definitions/Service.TaskArray",
+          "description": "task_array enables a job to be broken up into multiple tasks that run\nconcurrently. This is useful for doing embarassingly parallel compute\nwork."
+        },
+        "network": {
+          "$ref": "#/definitions/Service.Network",
+          "title": "network defines if the job should run inside its own netowrk namespace"
+        },
+        "script": {
+          "type": "string",
+          "title": "shellbang script executed via command"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "args passed to above script field, can also be passed to existing command"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "persist": {
+          "type": "boolean",
+          "description": "defines if the service should run even if there are no running or waiting jobs in the workflow. If persist: false then services are stopped when all jobs are finished (or do not start if there are no jobs at all). If persist: true then services run even if there are no jobs in the workflow and continue running if all jobs run, even if they fail."
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Port"
+          }
+        },
+        "proxy": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Proxy"
+          },
+          "description": "configures web UI reverse proxies for the specified port. In the example above, https://ui.stable.fuzzball.ciq.dev/accounts/${account}/workflows/${workflow}/jupyter proxies internally to http://jupyter.${workflow}.${account}.fuzzball:8888/."
+        }
+      }
+    },
+    "Service.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "Service.Multinode": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "nodes is the number of nodes to run job across in parallel."
+        },
+        "implementation": {
+          "type": "string",
+          "title": "implementation is the specific implementation of multinode to be used.\nThis must match the implementation used by the application within your\njob container because different multinode implementations require\nslightly different wire up configurations. Must be one of: \"ompi\",\n\"openmpi\", \"mpich\", \"gasnet\""
+        },
+        "procsPerNode": {
+          "type": "integer",
+          "format": "int64",
+          "description": "procs_per_node specifies the number of processes to spawn\nwithin each job container. If not specified, this value defaults to\nthe number of CPUs allocated to the job container. The total number\nof processes spawned for a job can be calculated by multiplying\nthis value by the number of nodes requested."
+        }
+      },
+      "description": "Multinode enables a job to run multiple containers across multiple nodes\nin parallel by leveraging various implementation for communication and\nsynchronization."
+    },
+    "Service.Network": {
+      "type": "object",
+      "properties": {
+        "isolated": {
+          "type": "boolean",
+          "description": "isolated forces the use of a container network namespace.\nThis is required for reaching a job container port with port\nforwarding."
+        },
+        "exposeTcp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_tcp is a list of container TCP ports to expose."
+        },
+        "exposeUdp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_udp is a list of container UDP ports to expose."
+        }
+      },
+      "description": "Network defines if the job should be run inside its own network namespace\nand enabled optional exposure of job container ports.\nThis is required if you want to expose ports from the job container\ndirectly or via port forwarding."
+    },
+    "Service.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/Service.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/Service.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "Service.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "Service.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "Service.TaskArray": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "format": "int64",
+          "description": "start is the start of the range for Task ID values. Inclusive."
+        },
+        "end": {
+          "type": "integer",
+          "format": "int64",
+          "description": "end is the end of the Task ID values. Inclusive."
+        },
+        "concurrency": {
+          "type": "integer",
+          "format": "int64",
+          "description": "concurrency is a limit on the number of tasks that can be run in\nparallel. The max concurrency for a workflow job is 200."
+        }
+      },
+      "description": "TaskArray allows a job to be broken up in an embarrassingly parallel\nmanner for more effective execution. TaskArray jobs are automatically\npopulated with a `FB_TASK_ID` environment variable to indicate the index\nwithin the task array range of the currently executing task to the\napplication."
+    },
+    "SetVolumeStatusBody": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        }
+      }
+    },
+    "SetVolumeStatusResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        }
+      }
+    },
+    "StageKind": {
+      "type": "string",
+      "enum": [
+        "STAGE_KIND_UNSPECIFIED",
+        "STAGE_KIND_WORKFLOW",
+        "STAGE_KIND_JOB",
+        "STAGE_KIND_FILE",
+        "STAGE_KIND_IMAGE",
+        "STAGE_KIND_VOLUME",
+        "STAGE_KIND_COMPLETED"
+      ],
+      "default": "STAGE_KIND_UNSPECIFIED"
+    },
+    "StartApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "title": "name to assign the workflow"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "StartWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        },
+        "rawSpecification": {
+          "type": "string"
+        }
+      }
+    },
+    "Status": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Any"
+          }
+        }
+      }
+    },
+    "StorageClassDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "mount": {
+          "$ref": "#/definitions/StorageClassDefinition.Mount"
+        },
+        "access": {
+          "$ref": "#/definitions/Access"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "secrets": {
+          "$ref": "#/definitions/Secrets"
+        },
+        "properties": {
+          "$ref": "#/definitions/Properties"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        },
+        "scope": {
+          "$ref": "#/definitions/Scope"
+        },
+        "capacity": {
+          "$ref": "#/definitions/Capacity"
+        },
+        "affinities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Affinity"
+          }
+        },
+        "volumes": {
+          "$ref": "#/definitions/Volumes"
+        },
+        "restricted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "StorageClassDefinition.Mount": {
+      "type": "object",
+      "properties": {
+        "filesystem": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "group": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "permissions": {
+          "type": "string"
+        }
+      }
+    },
+    "StorageClassInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "driverId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "class": {
+          "$ref": "#/definitions/StorageClassDefinition"
+        },
+        "scope": {
+          "$ref": "#/definitions/Scope"
+        },
+        "status": {
+          "$ref": "#/definitions/StorageClassStatus"
+        },
+        "restricted": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        },
+        "retain": {
+          "type": "boolean"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "StorageClassStatus": {
+      "type": "string",
+      "enum": [
+        "STORAGE_CLASS_STATUS_UNSPECIFIED",
+        "STORAGE_CLASS_STATUS_NOT_READY",
+        "STORAGE_CLASS_STATUS_READY",
+        "STORAGE_CLASS_STATUS_DISABLED",
+        "STORAGE_CLASS_STATUS_ERROR"
+      ],
+      "default": "STORAGE_CLASS_STATUS_UNSPECIFIED"
+    },
+    "SummarizedWorkflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "runningStages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        }
+      }
+    },
+    "SummarizedWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/SummarizedWorkflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "SupportedTemplateValues": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "TemplateValues": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "stringValue": {
+          "type": "string"
+        },
+        "uintValue": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "boolValue": {
+          "type": "boolean"
+        },
+        "secretValue": {
+          "$ref": "#/definitions/SecretTemplateValue"
+        },
+        "volumeValue": {
+          "$ref": "#/definitions/VolumeTemplateValue"
+        },
+        "displayCategory": {
+          "type": "string",
+          "title": "optional, used for UI grouping"
+        },
+        "optionsInput": {
+          "$ref": "#/definitions/OptionsInput",
+          "title": "optional, used for enum input"
+        }
+      }
+    },
+    "TerminalSize": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "cols": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "x": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "y": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Timeout": {
+      "type": "object",
+      "properties": {
+        "execute": {
+          "type": "string",
+          "description": "execute  is the maximum allowed duration of a workflow step to run\nbefore it is failed."
+        }
+      },
+      "description": "Timeout specifies rules related to the duration of a workflow step."
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "uri is the uri of the resource to be accessed."
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "secrets is a map of key value pairs to use to access resource.\nThe key specifies the type of data that is being used and the value\nspecifies raw data or a template for the workflow system to populate with\ndata internally from the secrets engine."
+        },
+        "secret": {
+          "type": "string"
+        },
+        "decryptionSecret": {
+          "type": "string"
+        }
+      },
+      "description": "URI contains the specification for a resource to access as well as\nadditional data necessary for access such as credentials."
+    },
+    "Unit": {
+      "type": "string",
+      "enum": [
+        "UNIT_UNSPECIFIED",
+        "MIB",
+        "GIB",
+        "TIB",
+        "PIB",
+        "EIB"
+      ],
+      "default": "UNIT_UNSPECIFIED"
+    },
+    "UpdateAccountBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/AccountRelationship"
+        }
+      }
+    },
+    "UpdateApplicationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateCatalogRepositoryBody": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateOrganizationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateOrganizationSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        }
+      }
+    },
+    "UpdateSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        }
+      }
+    },
+    "UpdateUserAccountResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateUserProfileAvatarRequest": {
+      "type": "object",
+      "properties": {
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "UpdateUserProfileRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateUserProfileSettingsRequest": {
+      "type": "object",
+      "properties": {
+        "settings": {
+          "type": "object"
+        }
+      },
+      "description": "TODO: given this is more of a backend support item we may want to remove this from the public api."
+    },
+    "UpdateVolumeBody": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/VolumeDefinition"
+        }
+      }
+    },
+    "UpsertApplicationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "templateSha": {
+          "type": "string"
+        },
+        "supportedValuesSha": {
+          "type": "string"
+        }
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "UserListResponse": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/User"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "UserProfile": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "organizationId": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        },
+        "settings": {
+          "type": "object"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ValidateWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        }
+      }
+    },
+    "ValidateWorkflowResponse": {
+      "type": "object"
+    },
+    "ValueSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "VersionGetResponse": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "Volume": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the key value of the volume in the volume map containing this\nstruct. This is normally set internally by client side code when parsing\nworkflow DSLs, but will need to be set when calling the API directly."
+        },
+        "type": {
+          "type": "string",
+          "title": "type is the kind of volume. This currently determines the lifetime of the\nvolume and the data contained within it.\nEphemeral volumes are empty upon creation and have a lifespan of the\nworkflow duration. Upon workflow completion the volume and its data are\ndeleted. Host volumes represent directories on the shared filesystems of\nthe nodes themselves. They must be pre-existing and fall under\ndirectories specified in the shared-fs-roots config property of the\nVolume service. Must be one of \"EPHEMERAL\" or \"HOST\".\nDeprecated in favor of reference"
+        },
+        "ingress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/File"
+          },
+          "description": "Ingress specifies data that should be fetched and made available within\nthe volume."
+        },
+        "egress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/File"
+          },
+          "description": "Egress specifies data that exists within the volume that should be\nexported to another storage location."
+        },
+        "path": {
+          "type": "string",
+          "title": "Path is specified for host volume types with the absolute path to the\ndirectory to mount.\nDeprecated: will be removed"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Volume reference this volume is referring to."
+        }
+      },
+      "description": "Volume is an instance of a data volume used within the scope of a workflow.\nThere are a couple different types of volumes that have different data\nretention behavior. Volumes are the means of managing data for compute\napplications to process over the course of a workflow and orchestrate\ndata movement to bring injest data into the bounds of a workflow for\ncomputation or export data generated from computation it to other storage\nlocations.\n\nTODO(cedric): deprecate type/path fields\n reserved 2, 5;\n reserved \"type\", \"path\";"
+    },
+    "VolumeDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "accessTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeStatus": {
+      "type": "string",
+      "enum": [
+        "VOLUME_STATUS_UNSPECIFIED",
+        "VOLUME_STATUS_ENABLED",
+        "VOLUME_STATUS_DISABLED"
+      ],
+      "default": "VOLUME_STATUS_UNSPECIFIED"
+    },
+    "VolumeTemplateValue": {
+      "type": "object",
+      "properties": {
+        "reference": {
+          "type": "string"
+        }
+      }
+    },
+    "Volumes": {
+      "type": "object",
+      "properties": {
+        "nameArgs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NameArg"
+          }
+        },
+        "nameFormat": {
+          "type": "string"
+        },
+        "maxByAccount": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Workflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "rawSpecification": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "jobs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        },
+        "totalJobs": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "version defines the version of the workflow document."
+        },
+        "volumes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Volume"
+          },
+          "description": "volumes is a map defining volumes to use for this workflow by name.\nMap keys define the name of the volume and values are specifications\ndetailing the data volume. Volume names are used by different\ncomponents of the workflow to reference a particular volume instance."
+        },
+        "jobs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowDefinition.Job"
+          },
+          "description": "jobs is a map defining jobs to run as a part of the workflow.\nMap keys define the name of the job and values are specifications\ndetailing the compute job. Job names are used by different components\nof the workflow to reference a particular compute job instance."
+        },
+        "completed": {
+          "$ref": "#/definitions/Completed",
+          "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Annotations for the whole workflow. Currently, this is used by the\nscheduler to place jobs in a certain topology zone"
+        },
+        "defaults": {
+          "$ref": "#/definitions/Defaults"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "files is a map defining files that may be injected into volumes and jobs.\nMap keys define the name of the file and values are the file's contents.\nFiles names are used by job and volume.ingress components\nto reference a specific file."
+        },
+        "services": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Service"
+          }
+        }
+      },
+      "description": "WorkflowDefinition is the highest level unit of work for a Fuzzball cluster.\nWorkflows consist of orchestrating data volumes, container images and\ncontainer execution across a compute cluster."
+    },
+    "WorkflowDefinition.Job": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Used internally to store the job name.  If this field is present in a\ndefinition then it will be ignored in preference for the map key used in\nthe `jobs` field."
+        },
+        "image": {
+          "$ref": "#/definitions/URI",
+          "title": "Image is the URI to the container image to be used for this job.\nSupported uri formats are: \"docker://...\" and \"oras://\" for OCI\nand SIF(Singularity Image Format) images respectively.\nE.g. docker://alpine:latest"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "command is the arguments executed by the container process."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside of the job\ncontainer."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowDefinition.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "cwd allows the specification of the the working dirctory used by the job.\nThis must be an absolute path. If unset the working directory defaults\nfirst to the working directory in the OCI image config if present and\nthen to \"/\"."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "requires is a list of prerequisite jobs in the workflow that must be\ncompleted before this job may be started. This allows jobs within a\nworkflow to be formed into a directed asyclic graph. If requirements\nspecified by different jobs results in a cycle, the workflow will fail to\nstart."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        },
+        "multinode": {
+          "$ref": "#/definitions/Job.Multinode",
+          "description": "multinode enables a job to run across multiple nodes in parallel."
+        },
+        "taskArray": {
+          "$ref": "#/definitions/Job.TaskArray",
+          "description": "task_array enables a job to be broken up into multiple tasks that run\nconcurrently. This is useful for doing embarassingly parallel compute\nwork."
+        },
+        "network": {
+          "$ref": "#/definitions/Job.Network",
+          "title": "network defines if the job should run inside its own netowrk namespace"
+        },
+        "script": {
+          "type": "string",
+          "title": "shellbang script executed via command"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "args passed to above script field, can also be passed to existing command"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Job is a single compute \"step\" in a workflow.\nThere are a variety of different types of jobs that\nresult in one or more containers being spawned.\nBy default, a single container is spawned unless the\nTaskArray or Multinode fields are specified."
+    },
+    "WorkflowDefinition.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "WorkflowDefinition.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "WorkflowDefinition.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "WorkflowDefinition.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "WorkflowGatewayAttachRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "stdin": {
+          "type": "boolean"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "ws": {
+          "$ref": "#/definitions/TerminalSize"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "WorkflowGatewayAttachResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowGatewayExecRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ws": {
+          "$ref": "#/definitions/TerminalSize"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "terminal": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "WorkflowGatewayExecResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        },
+        "exitCode": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowGatewayLogCommand": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+      ],
+      "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+    },
+    "WorkflowGatewayLogResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowGatewayLogShow": {
+      "type": "object",
+      "properties": {
+        "tail": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "follow": {
+          "type": "boolean"
+        }
+      }
+    },
+    "WorkflowGatewayPortForwardResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "WorkflowPlan": {
+      "type": "object",
+      "properties": {
+        "stages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        }
+      }
+    },
+    "WorkflowSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/ImageDecryptionSecret"
+        }
+      }
+    },
+    "WorkflowSecretsMap": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowSecret"
+          }
+        }
+      }
+    },
+    "WorkflowStage": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "kind": {
+          "$ref": "#/definitions/StageKind"
+        },
+        "error": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "details": {
+          "type": "object"
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowStatus": {
+      "type": "string",
+      "enum": [
+        "STAGE_STATUS_UNSPECIFIED",
+        "STAGE_STATUS_STARTED",
+        "STAGE_STATUS_FINISHED",
+        "STAGE_STATUS_FAILED",
+        "STAGE_STATUS_CANCELED"
+      ],
+      "default": "STAGE_STATUS_UNSPECIFIED",
+      "title": "- STAGE_STATUS_UNSPECIFIED: also used for pending"
+    }
+  }
+}

--- a/code-generation/schemas/fuzzball-v3.0-openapi.json
+++ b/code-generation/schemas/fuzzball-v3.0-openapi.json
@@ -1,0 +1,6577 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Fuzzball API",
+    "version": "3.0",
+    "contact": {
+      "name": "CtrlIQ, Inc",
+      "url": "https://ciq.com",
+      "email": "info@ciq.com"
+    }
+  },
+  "tags": [
+    {
+      "name": "AccountService"
+    },
+    {
+      "name": "ApplicationService"
+    },
+    {
+      "name": "ClusterService"
+    },
+    {
+      "name": "NodeService"
+    },
+    {
+      "name": "OrganizationService"
+    },
+    {
+      "name": "ProvisionerService"
+    },
+    {
+      "name": "SecretService"
+    },
+    {
+      "name": "StorageClassService"
+    },
+    {
+      "name": "StorageVolumeService"
+    },
+    {
+      "name": "UserService"
+    },
+    {
+      "name": "VersionService"
+    },
+    {
+      "name": "WorkflowService"
+    },
+    {
+      "name": "WorkflowGatewayService"
+    },
+    {
+      "name": "WorkflowGenerateService"
+    }
+  ],
+  "basePath": "/v3",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/accounts": {
+      "get": {
+        "operationId": "ListAccounts",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListAccountsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "showUserAccounts",
+            "description": "only valid for org/platform owners, by default all users/owners will only\nsee their own user account",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateAccountRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/update-user-account": {
+      "get": {
+        "operationId": "UpdateUserAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UpdateUserAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}": {
+      "get": {
+        "operationId": "GetAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members": {
+      "get": {
+        "operationId": "ListAccountMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "ACCOUNT_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "AddAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members/{userId}": {
+      "delete": {
+        "operationId": "RemoveAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "ACCOUNT_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/token": {
+      "get": {
+        "operationId": "SelectAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SelectAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/applications": {
+      "get": {
+        "operationId": "ListApplications",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListApplicationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/categories": {
+      "get": {
+        "operationId": "ListApplicationCategories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListApplicationCategoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "operationId": "GetApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:bundle": {
+      "get": {
+        "operationId": "GetApplicationBundle",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetApplicationBundleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "excludedParts",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "TEMPLATE",
+                "VALUES",
+                "METADATA"
+              ]
+            },
+            "collectionFormat": "multi"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:disable": {
+      "put": {
+        "operationId": "DisableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:enable": {
+      "put": {
+        "operationId": "EnableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:render": {
+      "post": {
+        "operationId": "RenderApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:upsert": {
+      "patch": {
+        "operationId": "UpsertApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpsertApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:copy": {
+      "post": {
+        "operationId": "CopyApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CopyApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:render": {
+      "post": {
+        "operationId": "RenderApplicationTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenderApplicationTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:start": {
+      "post": {
+        "operationId": "StartApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StartApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories": {
+      "get": {
+        "operationId": "ListCatalogRepositories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListCatalogRepositoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "AddCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddCatalogRepositoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories/{id}": {
+      "get": {
+        "operationId": "GetCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CatalogRepositorySummary"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateCatalogRepositoryBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories/{id}:reload": {
+      "post": {
+        "operationId": "ReloadCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ReloadCatalogRepositoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReloadCatalogRepositoryBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories:import": {
+      "post": {
+        "operationId": "ImportCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ImportCatalogRepositoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ImportCatalogRepositoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/sync:updateSchedule": {
+      "post": {
+        "operationId": "ScheduleCatalogSync",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ScheduleCatalogSyncRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/cluster/{id}": {
+      "get": {
+        "operationId": "GetCluster",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Cluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/clusters": {
+      "get": {
+        "operationId": "ListClusters",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListClustersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/nodes": {
+      "get": {
+        "operationId": "ListNodes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListNodesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "NodeService"
+        ]
+      }
+    },
+    "/organization": {
+      "get": {
+        "operationId": "GetOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrganizationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members": {
+      "get": {
+        "operationId": "ListOrganizationMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "post": {
+        "operationId": "AddOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddOrganizationMemberRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members/{id}": {
+      "delete": {
+        "operationId": "RemoveOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/secrets": {
+      "get": {
+        "operationId": "ListOrganizationSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/organization/secrets/{id}": {
+      "get": {
+        "operationId": "GetOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateOrganizationSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/profile": {
+      "get": {
+        "operationId": "GetUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "UserService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/avatar": {
+      "patch": {
+        "operationId": "UpdateUserProfileAvatar",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileAvatarRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/settings": {
+      "patch": {
+        "summary": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+        "operationId": "UpdateUserProfileSettings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserProfileSettingsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/provisioner/definitions": {
+      "get": {
+        "operationId": "ListProvisionerDefinitions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListProvisionerDefinitionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionerService"
+        ]
+      }
+    },
+    "/provisioner/definitions/{id}": {
+      "get": {
+        "operationId": "GetProvisionerDefinition",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ProvisionerDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionerService"
+        ]
+      }
+    },
+    "/secrets": {
+      "get": {
+        "operationId": "ListSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/secrets/{id}": {
+      "get": {
+        "operationId": "GetSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/storage-classes": {
+      "get": {
+        "operationId": "ListStorageClasses",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListStorageClassesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/storage-classes/{id}": {
+      "get": {
+        "operationId": "GetStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/StorageClassInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/stream/workflow/attach": {
+      "post": {
+        "operationId": "WorkflowGatewayAttach",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayAttachResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayAttachResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowGatewayAttachRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/exec": {
+      "post": {
+        "operationId": "WorkflowGatewayExec",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayExecResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayExecResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkflowGatewayExecRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/generate": {
+      "post": {
+        "operationId": "GenerateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/GenerateWorkflowServerMessage"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of GenerateWorkflowServerMessage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GenerateWorkflowClientMessage"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGenerateService"
+        ]
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Get the fuzzball agent version",
+        "operationId": "VersionGet",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VersionGetResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "tags": [
+          "VersionService"
+        ]
+      }
+    },
+    "/volumes": {
+      "get": {
+        "operationId": "ListVolumes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListVolumesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateVolumeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}": {
+      "get": {
+        "operationId": "GetVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateVolumeBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}:set-status": {
+      "patch": {
+        "operationId": "SetVolumeStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SetVolumeStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetVolumeStatusBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/workflows": {
+      "get": {
+        "summary": "List workflows",
+        "operationId": "ListWorkflows",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListWorkflowsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "status",
+            "description": "Deprecated as this was not used and we need ability to filter by multiple statuses.\n\n - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "requestedStatuses",
+            "description": "Allows multiple statuses to be requested.\n\n - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "STAGE_STATUS_UNSPECIFIED",
+                "STAGE_STATUS_STARTED",
+                "STAGE_STATUS_FINISHED",
+                "STAGE_STATUS_FAILED",
+                "STAGE_STATUS_CANCELED"
+              ]
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "scope",
+            "description": " - SCOPE_USER: Only return workflows for the user for the currently selected account\n - SCOPE_ACCOUNT: Return workflows for the account",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SCOPE_UNSPECIFIED",
+              "SCOPE_USER",
+              "SCOPE_ACCOUNT"
+            ],
+            "default": "SCOPE_UNSPECIFIED"
+          },
+          {
+            "name": "aipFilter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "summary": "Start a new workflow",
+        "operationId": "StartWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StartWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary": {
+      "get": {
+        "summary": "Get a summary of workflows",
+        "operationId": "GetWorkflowsSummary",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkflowsSummaryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "userWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "otherOwnerWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary/account-owner/details": {
+      "get": {
+        "summary": "Get workflow summary details",
+        "operationId": "GetAccountOwnerWorkflowsSummaryDetails",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetAccountOwnerWorkflowsSummaryDetailsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "requestedStatus",
+            "description": " - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary/account-owner/users": {
+      "get": {
+        "summary": "Account owners request workflows in some state.",
+        "operationId": "GetAccountOwnerWorkflowsUsers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetAccountOwnerWorkflowsUsersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "requestedStatus",
+            "description": " - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}": {
+      "get": {
+        "summary": "Get details on a workflow",
+        "operationId": "GetWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/Workflow"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners": {
+      "get": {
+        "operationId": "ListWorkflowOwners",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "operationId": "AddWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddWorkflowOwnerBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners/{userId}": {
+      "delete": {
+        "operationId": "RemoveWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:log": {
+      "get": {
+        "operationId": "WorkflowGatewayLog",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/WorkflowGatewayLogResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/Status"
+                }
+              },
+              "title": "Stream result of WorkflowGatewayLogResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "show.tail",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "show.follow",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "command",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+            ],
+            "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+          },
+          {
+            "name": "name",
+            "description": "Name of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "rank",
+            "description": "Rank of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/workflows/{id}:status": {
+      "get": {
+        "summary": "Get the status on a workflow",
+        "operationId": "GetWorkflowStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkflowStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:stop": {
+      "patch": {
+        "summary": "Stop a workflow",
+        "operationId": "StopWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:score": {
+      "patch": {
+        "summary": "ScoreWorkflow returns the score for a workflow definition.",
+        "operationId": "ScoreWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ScoreWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ScoreWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:validate": {
+      "post": {
+        "summary": "Validate a workflow definition",
+        "operationId": "ValidateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ValidateWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Access": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Access.Type"
+        },
+        "mode": {
+          "$ref": "#/definitions/Mode"
+        }
+      }
+    },
+    "Access.Type": {
+      "type": "string",
+      "enum": [
+        "TYPE_UNSPECIFIED",
+        "FILESYSTEM",
+        "BLOCK"
+      ],
+      "default": "TYPE_UNSPECIFIED",
+      "title": "- BLOCK: BLOCK is not supported yet"
+    },
+    "Account": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "AccountOwnerWorkflowsSummary": {
+      "type": "object",
+      "properties": {
+        "currentWorkflowsStarted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentWorkflowsPending": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "averageWorkflowPendingMilliseconds": {
+          "type": "number",
+          "format": "double"
+        },
+        "workflowsCompleted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "totalAccountUsers": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "AccountOwnerWorkflowsSummaryDetails": {
+      "type": "object",
+      "properties": {
+        "workflowsResponse": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        }
+      }
+    },
+    "AccountRelationship": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT_MEMBER",
+        "ACCOUNT_OWNER"
+      ],
+      "default": "ACCOUNT_MEMBER"
+    },
+    "AddAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/AccountRelationship"
+        }
+      }
+    },
+    "AddCatalogRepositoryRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        }
+      }
+    },
+    "AddOrganizationMemberRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/OrganizationRelationship"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "AddWorkflowOwnerBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        }
+      }
+    },
+    "Affinity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Affinity.Type"
+        },
+        "key": {
+          "type": "string"
+        },
+        "filter": {
+          "type": "string"
+        }
+      }
+    },
+    "Affinity.Type": {
+      "type": "string",
+      "enum": [
+        "AFFINITY_UNSPECIFIED",
+        "ANNOTATION",
+        "RESOURCE"
+      ],
+      "default": "AFFINITY_UNSPECIFIED"
+    },
+    "Any": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "Application": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "templateSha": {
+          "type": "string"
+        },
+        "supportedValueSha": {
+          "type": "string"
+        },
+        "createdBy": {
+          "type": "string"
+        },
+        "createdByEmail": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationBundlePart": {
+      "type": "string",
+      "enum": [
+        "TEMPLATE",
+        "VALUES",
+        "METADATA"
+      ],
+      "default": "TEMPLATE"
+    },
+    "ApplicationCategory": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationMetadata": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationOwnerKind": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT",
+        "ORGANIZATION",
+        "PROVIDER"
+      ],
+      "default": "ACCOUNT",
+      "title": "- ACCOUNT: default\n - ORGANIZATION: must be an organization owner to use\n - PROVIDER: only available via direct sql updates (for now)"
+    },
+    "Capability": {
+      "type": "string",
+      "enum": [
+        "CAPABILITY_UNSPECIFIED",
+        "SELINUX"
+      ],
+      "default": "CAPABILITY_UNSPECIFIED"
+    },
+    "Capacity": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "unit": {
+          "$ref": "#/definitions/Unit"
+        }
+      }
+    },
+    "CatalogRepository": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "CatalogRepositorySummary": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "Cluster": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/ClusterKind"
+        },
+        "status": {
+          "$ref": "#/definitions/ClusterStatus"
+        },
+        "apiEndpoint": {
+          "type": "string"
+        },
+        "openapiEndpoint": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "ClusterKind": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_KIND_UNSPECIFIED",
+        "CLUSTER_KIND_ORCHESTRATE",
+        "CLUSTER_KIND_FEDERATE"
+      ],
+      "default": "CLUSTER_KIND_UNSPECIFIED"
+    },
+    "ClusterStatus": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_STATUS_UNSPECIFIED",
+        "CLUSTER_STATUS_UNSYNCED",
+        "CLUSTER_STATUS_SYNCING",
+        "CLUSTER_STATUS_READY",
+        "CLUSTER_STATUS_UNREACHABLE",
+        "CLUSTER_STATUS_ERROR",
+        "CLUSTER_STATUS_DISABLED"
+      ],
+      "default": "CLUSTER_STATUS_UNSPECIFIED"
+    },
+    "Completed": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      },
+      "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+    },
+    "CopyApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        }
+      }
+    },
+    "Core": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64",
+          "title": "core identifier"
+        },
+        "hardwareThreads": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of hardware threads of the core (nil for threads)"
+        },
+        "socketPackage": {
+          "type": "integer",
+          "format": "int64",
+          "title": "socket package associated to the core"
+        },
+        "numaNode": {
+          "type": "integer",
+          "format": "int64",
+          "title": "NUMA node associated to the core"
+        },
+        "allocated": {
+          "type": "boolean",
+          "title": "core allocation state"
+        }
+      }
+    },
+    "CpuAffinity": {
+      "type": "string",
+      "enum": [
+        "CPU_AFFINITY_UNSPECIFIED",
+        "CPU_AFFINITY_NUMA",
+        "CPU_AFFINITY_SOCKET",
+        "CPU_AFFINITY_CORE"
+      ],
+      "default": "CPU_AFFINITY_UNSPECIFIED"
+    },
+    "CpuResource": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "$ref": "#/definitions/CpuAffinity"
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "threads": {
+          "type": "boolean"
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "CreateAccountRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "CreateApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string",
+          "title": "if not provided a default will be set"
+        }
+      }
+    },
+    "CreateSecretRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/SecretScope"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        },
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/ImageDecryptionSecret"
+        }
+      }
+    },
+    "CreateVolumeRequest": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/VolumeDefinition"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "Defaults": {
+      "type": "object",
+      "properties": {
+        "job": {
+          "$ref": "#/definitions/Defaults.Job"
+        }
+      },
+      "description": "Default defines the default settings that should be applied to all jobs in the workflow.\nThese can be overridden at the job level."
+    },
+    "Defaults.Job": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside all job\ncontainers.  Will be overridden by job level env variables."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Defaults.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/Defaults.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        }
+      }
+    },
+    "Defaults.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "Defaults.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/Defaults.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/Defaults.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "Defaults.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "Defaults.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "Dependency": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name is the name of the job to depend on."
+        },
+        "status": {
+          "type": "string",
+          "title": "status is the status that this dependency must be in before this job can run.\nValid values: ERROR, STARTED, RUNNING, FINISHED, CANCELLED (case insensitive)"
+        },
+        "description": {
+          "type": "string",
+          "description": "description is a human readable description of the dependency."
+        }
+      },
+      "description": "Dependency is a concrete dependency that must be satisfied before this job can run."
+    },
+    "Device": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Device ID."
+        },
+        "numa-node": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Numa node associated to the device."
+        },
+        "consumable": {
+          "type": "boolean",
+          "title": "The device is consumable ?"
+        },
+        "allocated": {
+          "type": "boolean",
+          "title": "Is the device allocated, only used for fuzzball.substrate.api.substrate.v1.ResourceShowResponse,\nthis field is ignored when set by a plugin returning DeviceInitResponse"
+        }
+      },
+      "description": "Device represents a single device."
+    },
+    "DeviceList": {
+      "type": "object",
+      "properties": {
+        "devices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Device"
+          }
+        }
+      },
+      "description": "Devices holds the device list."
+    },
+    "Devices": {
+      "type": "object",
+      "properties": {
+        "list": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DeviceList"
+          }
+        }
+      },
+      "description": "Devices managed by a plugin."
+    },
+    "Export": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW",
+        "ACCOUNT",
+        "CLUSTER",
+        "PUBLIC"
+      ],
+      "default": "WORKFLOW"
+    },
+    "File": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/URI",
+          "description": "Source is the origin of the data. The type of URIs supported are\ndetermined by whether this is specified under ingress or egress."
+        },
+        "destination": {
+          "$ref": "#/definitions/URI",
+          "description": "Destination is the location to move the data. The type of URIs\nsupported are determined by whether this is specified under ingress or\negress."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a data transfer such as max execution time and retries on\nfailure."
+        }
+      },
+      "description": "File specifies details of workflow volume data movement."
+    },
+    "GenerateWorkflowClientMessage": {
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "GenerateWorkflowServerMessage": {
+      "type": "object",
+      "properties": {
+        "workflowYaml": {
+          "type": "string"
+        },
+        "response": {
+          "type": "string"
+        }
+      }
+    },
+    "GetAccountOwnerWorkflowsSummaryDetailsResponse": {
+      "type": "object",
+      "properties": {
+        "accountOwnerWorkflowsSummaryDetails": {
+          "$ref": "#/definitions/AccountOwnerWorkflowsSummaryDetails"
+        }
+      }
+    },
+    "GetAccountOwnerWorkflowsUsersResponse": {
+      "type": "object",
+      "properties": {
+        "workflowEmails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GetApplicationBundleResponse": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        },
+        "values": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "string"
+        }
+      }
+    },
+    "GetWorkflowStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/WorkflowPlan"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "workflowStatus": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "GetWorkflowsSummaryResponse": {
+      "type": "object",
+      "properties": {
+        "userWorkflows": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        },
+        "otherOwnerWorkflows": {
+          "$ref": "#/definitions/SummarizedWorkflowResponse"
+        },
+        "accountOwnerWorkflowsSummary": {
+          "$ref": "#/definitions/AccountOwnerWorkflowsSummary"
+        }
+      }
+    },
+    "HTTPSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "HTTPSecretInfo": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageDecryptionSecret": {
+      "type": "object",
+      "properties": {
+        "passphrase": {
+          "type": "string"
+        },
+        "pem": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "ImageSecretInfo": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "ImportCatalogRepositoryRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        }
+      }
+    },
+    "ImportCatalogRepositoryResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "ListAccountsResponse": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Account"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListApplicationCategoriesResponse": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ApplicationCategory"
+          }
+        }
+      }
+    },
+    "ListApplicationsResponse": {
+      "type": "object",
+      "properties": {
+        "applications": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ApplicationMetadata"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListCatalogRepositoriesResponse": {
+      "type": "object",
+      "properties": {
+        "repositories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/CatalogRepositorySummary"
+          }
+        }
+      }
+    },
+    "ListClustersResponse": {
+      "type": "object",
+      "properties": {
+        "clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Cluster"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListNodeInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "hostName": {
+          "type": "string"
+        },
+        "cpu": {
+          "type": "string"
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "memoryGb": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "devices": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "runningJobs": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "ListNodesResponse": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ListNodeInfo"
+          }
+        }
+      }
+    },
+    "ListProvisionerDefinitionsResponse": {
+      "type": "object",
+      "properties": {
+        "definitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ProvisionerDefinition"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListSecretsResponse": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Secret"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListStorageClassesResponse": {
+      "type": "object",
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/StorageClassInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListVolumesResponse": {
+      "type": "object",
+      "properties": {
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/VolumeInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListWorkflowsResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Workflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "ListWorkflowsScope": {
+      "type": "string",
+      "enum": [
+        "SCOPE_UNSPECIFIED",
+        "SCOPE_USER",
+        "SCOPE_ACCOUNT"
+      ],
+      "default": "SCOPE_UNSPECIFIED",
+      "title": "- SCOPE_USER: Only return workflows for the user for the currently selected account\n - SCOPE_ACCOUNT: Return workflows for the account"
+    },
+    "MapSecret": {
+      "type": "object",
+      "properties": {
+        "map": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MemResource": {
+      "type": "object",
+      "properties": {
+        "bytes": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "byCore": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Mode": {
+      "type": "string",
+      "enum": [
+        "MODE_UNSPECIFIED",
+        "SINGLE_NODE_WRITER",
+        "SINGLE_NODE_READER_ONLY",
+        "MULTI_NODE_READER_ONLY",
+        "MULTI_NODE_SINGLE_WRITER",
+        "MULTI_NODE_MULTI_WRITER",
+        "SINGLE_NODE_SINGLE_WRITER",
+        "SINGLE_NODE_MULTI_WRITER"
+      ],
+      "default": "MODE_UNSPECIFIED",
+      "title": "- MODE_UNSPECIFIED: SINGLE_NODE_XXX are not supported yet\n - MULTI_NODE_SINGLE_WRITER: not supported yet"
+    },
+    "Multinode": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "nodes is the number of nodes to run job across in parallel."
+        },
+        "implementation": {
+          "type": "string",
+          "title": "implementation is the specific implementation of multinode to be used.\nThis must match the implementation used by the application within your\njob container because different multinode implementations require\nslightly different wire up configurations. Must be one of: \"ompi\",\n\"openmpi\", \"mpich\", \"gasnet\""
+        },
+        "procsPerNode": {
+          "type": "integer",
+          "format": "int64",
+          "description": "procs_per_node specifies the number of processes to spawn\nwithin each job container. If not specified, this value defaults to\nthe number of CPUs allocated to the job container. The total number\nof processes spawned for a job can be calculated by multiplying\nthis value by the number of nodes requested."
+        }
+      },
+      "description": "Multinode enables a job to run multiple containers across multiple nodes\nin parallel by leveraging various implementation for communication and\nsynchronization."
+    },
+    "NameArg": {
+      "type": "string",
+      "enum": [
+        "NAME_ARG_UNSPECIFIED",
+        "USERNAME",
+        "ORGANIZATION_ID",
+        "ACCOUNT_ID",
+        "WORKFLOW_ID",
+        "CUSTOM_NAME"
+      ],
+      "default": "NAME_ARG_UNSPECIFIED"
+    },
+    "Network": {
+      "type": "object",
+      "properties": {
+        "isolated": {
+          "type": "boolean",
+          "description": "isolated forces the use of a container network namespace.\nThis is required for reaching a job container port with port\nforwarding."
+        },
+        "exposeTcp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_tcp is a list of container TCP ports to expose."
+        },
+        "exposeUdp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_udp is a list of container UDP ports to expose."
+        }
+      },
+      "description": "Network defines if the job should be run inside its own network namespace\nand enabled optional exposure of job container ports.\nThis is required if you want to expose ports from the job container\ndirectly or via port forwarding."
+    },
+    "NodeResource": {
+      "type": "object",
+      "properties": {
+        "cores": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Core"
+          },
+          "title": "list of CPU cores on a system"
+        },
+        "freeCores": {
+          "type": "integer",
+          "format": "int64",
+          "title": "number of free CPU cores (hardware threads are not accounted)"
+        },
+        "memoryTotalBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "total memory available on a system"
+        },
+        "memoryFreeBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "free memory available on a system"
+        },
+        "memoryBytesByCore": {
+          "type": "string",
+          "format": "uint64",
+          "title": "rough estimation of the amount of memory available by CPU core"
+        },
+        "threads": {
+          "type": "boolean",
+          "title": "hardware threads support"
+        },
+        "numaNodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/NumaNode"
+          },
+          "title": "NUMA nodes available on a system"
+        },
+        "sockets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Socket"
+          },
+          "title": "sockets available on a system"
+        }
+      }
+    },
+    "NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    },
+    "NumaNode": {
+      "type": "object",
+      "properties": {
+        "cores": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of CPU cores associated to a NUMA node"
+        },
+        "freeCores": {
+          "type": "integer",
+          "format": "int64",
+          "title": "number of free CPU cores (hardware threads are not accounted)"
+        },
+        "memoryTotalBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "total memory available on a NUMA node"
+        },
+        "memoryFreeBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "free memory available on a NUMA node"
+        },
+        "memoryBytesByCore": {
+          "type": "string",
+          "format": "uint64",
+          "title": "rough estimation of the amount of memory available by CPU core"
+        }
+      }
+    },
+    "OptionsInput": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "list of options for the input"
+        }
+      }
+    },
+    "Organization": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "OrganizationRelationship": {
+      "type": "string",
+      "enum": [
+        "ORGANIZATION_MEMBER",
+        "ORGANIZATION_OWNER"
+      ],
+      "default": "ORGANIZATION_MEMBER"
+    },
+    "Ownership": {
+      "type": "string",
+      "enum": [
+        "OWNERSHIP_UNSPECIFIED",
+        "ROOT",
+        "USER",
+        "ACCOUNT"
+      ],
+      "default": "OWNERSHIP_UNSPECIFIED",
+      "title": "- ACCOUNT: ACCOUNT is supported with group ownership only"
+    },
+    "Policy": {
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "$ref": "#/definitions/Timeout",
+          "description": "timeout specifies rules related to the duration of a workflow step."
+        },
+        "retry": {
+          "$ref": "#/definitions/Retry",
+          "description": "retry specifies rules related to rerunning a workflow step in case of\nfailure."
+        }
+      },
+      "description": "Policy contains configurable rules for the execution of a workflow step.\nThe default policy for a step will set a value for timeout if a custom one\nis not specified."
+    },
+    "Port": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "export": {
+          "$ref": "#/definitions/Export"
+        }
+      },
+      "title": "ports:\n   8888/tcp:\n   export: workflow # workflow, account, cluster"
+    },
+    "Properties": {
+      "type": "object",
+      "properties": {
+        "retainOnDelete": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ProvisionerDefinition": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "backendId": {
+          "type": "string"
+        },
+        "resource": {
+          "$ref": "#/definitions/ResourceShowResponse"
+        },
+        "costPerHourEstimate": {
+          "type": "number",
+          "format": "double"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "Proxy": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "ReloadCatalogRepositoryBody": {
+      "type": "object"
+    },
+    "ReloadCatalogRepositoryResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "RenderApplicationBody": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "RenderApplicationTemplateRequest": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "RenderApplicationTemplateResponse": {
+      "type": "object",
+      "properties": {
+        "renderedWorkflow": {
+          "type": "string"
+        }
+      }
+    },
+    "ResourceShowResponse": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "$ref": "#/definitions/v1.Resource",
+          "description": "total is the total available resource on the compute service."
+        },
+        "free": {
+          "$ref": "#/definitions/v1.Resource",
+          "description": "free is the currently free resource on the compute service."
+        },
+        "node": {
+          "$ref": "#/definitions/NodeResource",
+          "description": "node is the detailed node information of the compute service."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is the list of annotations associated with the node."
+        },
+        "pluginDevices": {
+          "$ref": "#/definitions/Devices",
+          "description": "Plugin devices details."
+        }
+      }
+    },
+    "Retry": {
+      "type": "object",
+      "properties": {
+        "attempts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "attempts is the number of retry attemps before failing the step\ncompletely."
+        }
+      },
+      "description": "Retry specifies rules related to rerunning a workflow step in case of\nfailure."
+    },
+    "S3Secret": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string"
+        },
+        "accessKey": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "sessionToken": {
+          "type": "string"
+        }
+      }
+    },
+    "S3SecretInfo": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      },
+      "title": "Non-sensitive information about secrets"
+    },
+    "ScheduleCatalogSyncRequest": {
+      "type": "object",
+      "properties": {
+        "cron": {
+          "type": "string"
+        },
+        "suspend": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Scope": {
+      "type": "string",
+      "enum": [
+        "SCOPE_UNSPECIFIED",
+        "ALL",
+        "USER",
+        "ACCOUNT"
+      ],
+      "default": "SCOPE_UNSPECIFIED"
+    },
+    "ScoreWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        },
+        "withChecks": {
+          "type": "boolean"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        }
+      }
+    },
+    "ScoreWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "score": {
+          "type": "number",
+          "format": "float"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costEstimate": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "Secret": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/SecretScope"
+        },
+        "type": {
+          "$ref": "#/definitions/SecretType"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3SecretInfo"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecretInfo"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecretInfo"
+        }
+      }
+    },
+    "SecretIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "SecretScope": {
+      "type": "string",
+      "enum": [
+        "SECRET_SCOPE_UNSPECIFIED",
+        "SECRET_SCOPE_USER",
+        "SECRET_SCOPE_ACCOUNT",
+        "SECRET_SCOPE_ORGANIZATION",
+        "SECRET_SCOPE_CLUSTER"
+      ],
+      "default": "SECRET_SCOPE_UNSPECIFIED"
+    },
+    "SecretTemplateValue": {
+      "type": "object",
+      "properties": {
+        "reference": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/SecretType"
+        }
+      }
+    },
+    "SecretType": {
+      "type": "string",
+      "enum": [
+        "SECRET_TYPE_UNSPECIFIED",
+        "SECRET_TYPE_VALUE",
+        "SECRET_TYPE_S3",
+        "SECRET_TYPE_HTTP",
+        "SECRET_TYPE_IMAGE",
+        "SECRET_TYPE_MAP",
+        "SECRET_TYPE_DECRYPTION_SIF",
+        "UNSPECIFIED",
+        "VALUE",
+        "S3",
+        "HTTP",
+        "IMAGE",
+        "MAP",
+        "DECRYPTION_SIF"
+      ],
+      "default": "SECRET_TYPE_UNSPECIFIED"
+    },
+    "Secrets": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string"
+        }
+      }
+    },
+    "SelectAccountResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "Service": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Used internally to store the job name.  If this field is present in a\ndefinition then it will be ignored in preference for the map key used in\nthe `jobs` field."
+        },
+        "image": {
+          "$ref": "#/definitions/URI",
+          "title": "Image is the URI to the container image to be used for this job.\nSupported uri formats are: \"docker://...\" and \"oras://\" for OCI\nand SIF(Singularity Image Format) images respectively.\nE.g. docker://alpine:latest"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "command is the arguments executed by the container process."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside of the job\ncontainer."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowDefinition.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "cwd allows the specification of the the working dirctory used by the job.\nThis must be an absolute path. If unset the working directory defaults\nfirst to the working directory in the OCI image config if present and\nthen to \"/\"."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "requires is a list of prerequisite jobs/services in the workflow that must be\ncompleted before this service may be started. This allows jobs within a\nworkflow to be formed into a directed acyclic graph. If requirements\nspecified by different jobs results in a cycle, the workflow will fail to\nstart.\n\nDeprecated: use the `dependsOn` field instead.\nIgnored if `dependsOn` is set.\nIf used instead of `dependsOn`, dependencies are assumed to be \"when jobN has finished\"."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        },
+        "multinode": {
+          "$ref": "#/definitions/Multinode",
+          "description": "multinode enables a service to run across multiple nodes in parallel."
+        },
+        "network": {
+          "$ref": "#/definitions/Network",
+          "title": "network defines if the service should run inside its own network namespace"
+        },
+        "script": {
+          "type": "string",
+          "title": "shellbang script executed via command"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "args passed to above script field, can also be passed to existing command"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Dependency"
+          },
+          "description": "dependsOn is a list of concrete dependencies that must be satisfied before this service can run."
+        },
+        "persist": {
+          "type": "boolean",
+          "description": "defines if the service should run even if there are no running or waiting jobs in the workflow. If persist: false then services are stopped when all jobs are finished (or do not start if there are no jobs at all). If persist: true then services run even if there are no jobs in the workflow and continue running if all jobs run, even if they fail."
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Port"
+          }
+        },
+        "proxy": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Proxy"
+          },
+          "description": "configures web UI reverse proxies for the specified port. In the example above, https://ui.stable.fuzzball.ciq.dev/accounts/${account}/workflows/${workflow}/jupyter proxies internally to http://jupyter.${workflow}.${account}.fuzzball:8888/."
+        }
+      }
+    },
+    "SetVolumeStatusBody": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        }
+      }
+    },
+    "SetVolumeStatusResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        }
+      }
+    },
+    "Socket": {
+      "type": "object",
+      "properties": {
+        "cores": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of CPU cores associated to a socket"
+        },
+        "freeCores": {
+          "type": "integer",
+          "format": "int64",
+          "title": "number of free CPU cores (hardware threads are not accounted)"
+        },
+        "numaNodes": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of NUMA nodes associated to a socket"
+        }
+      }
+    },
+    "StageKind": {
+      "type": "string",
+      "enum": [
+        "STAGE_KIND_UNSPECIFIED",
+        "STAGE_KIND_WORKFLOW",
+        "STAGE_KIND_JOB",
+        "STAGE_KIND_FILE",
+        "STAGE_KIND_IMAGE",
+        "STAGE_KIND_VOLUME",
+        "STAGE_KIND_COMPLETED"
+      ],
+      "default": "STAGE_KIND_UNSPECIFIED"
+    },
+    "StartApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "title": "name to assign the workflow"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "StartWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        },
+        "rawSpecification": {
+          "type": "string"
+        }
+      }
+    },
+    "Status": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Any"
+          }
+        }
+      }
+    },
+    "StorageClassDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "mount": {
+          "$ref": "#/definitions/StorageClassDefinition.Mount"
+        },
+        "access": {
+          "$ref": "#/definitions/Access"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "secrets": {
+          "$ref": "#/definitions/Secrets"
+        },
+        "properties": {
+          "$ref": "#/definitions/Properties"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        },
+        "scope": {
+          "$ref": "#/definitions/Scope"
+        },
+        "capacity": {
+          "$ref": "#/definitions/Capacity"
+        },
+        "affinities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Affinity"
+          }
+        },
+        "volumes": {
+          "$ref": "#/definitions/Volumes"
+        },
+        "restricted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "StorageClassDefinition.Mount": {
+      "type": "object",
+      "properties": {
+        "filesystem": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "group": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "permissions": {
+          "type": "string"
+        }
+      }
+    },
+    "StorageClassInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "driverId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "class": {
+          "$ref": "#/definitions/StorageClassDefinition"
+        },
+        "scope": {
+          "$ref": "#/definitions/Scope"
+        },
+        "status": {
+          "$ref": "#/definitions/StorageClassStatus"
+        },
+        "restricted": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        },
+        "retain": {
+          "type": "boolean"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "StorageClassStatus": {
+      "type": "string",
+      "enum": [
+        "STORAGE_CLASS_STATUS_UNSPECIFIED",
+        "STORAGE_CLASS_STATUS_NOT_READY",
+        "STORAGE_CLASS_STATUS_READY",
+        "STORAGE_CLASS_STATUS_DISABLED",
+        "STORAGE_CLASS_STATUS_ERROR"
+      ],
+      "default": "STORAGE_CLASS_STATUS_UNSPECIFIED"
+    },
+    "SummarizedWorkflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "runningStages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        }
+      }
+    },
+    "SummarizedWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/SummarizedWorkflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "SupportedTemplateValues": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/TemplateValues"
+          }
+        }
+      }
+    },
+    "TaskArray": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "format": "int64",
+          "description": "start is the start of the range for Task ID values. Inclusive."
+        },
+        "end": {
+          "type": "integer",
+          "format": "int64",
+          "description": "end is the end of the Task ID values. Inclusive."
+        },
+        "concurrency": {
+          "type": "integer",
+          "format": "int64",
+          "description": "concurrency is a limit on the number of tasks that can be run in\nparallel. The max concurrency for a workflow job is 200."
+        }
+      },
+      "description": "TaskArray allows a job to be broken up in an embarrassingly parallel\nmanner for more effective execution. TaskArray jobs are automatically\npopulated with a `FB_TASK_ID` environment variable to indicate the index\nwithin the task array range of the currently executing task to the\napplication."
+    },
+    "TemplateValues": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "stringValue": {
+          "type": "string"
+        },
+        "uintValue": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "boolValue": {
+          "type": "boolean"
+        },
+        "secretValue": {
+          "$ref": "#/definitions/SecretTemplateValue"
+        },
+        "volumeValue": {
+          "$ref": "#/definitions/VolumeTemplateValue"
+        },
+        "displayCategory": {
+          "type": "string",
+          "title": "optional, used for UI grouping"
+        },
+        "optionsInput": {
+          "$ref": "#/definitions/OptionsInput",
+          "title": "optional, used for enum input"
+        }
+      }
+    },
+    "TerminalSize": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "cols": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "x": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "y": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Timeout": {
+      "type": "object",
+      "properties": {
+        "execute": {
+          "type": "string",
+          "description": "execute  is the maximum allowed duration of a workflow step to run\nbefore it is failed."
+        }
+      },
+      "description": "Timeout specifies rules related to the duration of a workflow step."
+    },
+    "URI": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "uri is the uri of the resource to be accessed."
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "secrets is a map of key value pairs to use to access resource.\nThe key specifies the type of data that is being used and the value\nspecifies raw data or a template for the workflow system to populate with\ndata internally from the secrets engine."
+        },
+        "secret": {
+          "type": "string"
+        },
+        "decryptionSecret": {
+          "type": "string"
+        }
+      },
+      "description": "URI contains the specification for a resource to access as well as\nadditional data necessary for access such as credentials."
+    },
+    "Unit": {
+      "type": "string",
+      "enum": [
+        "UNIT_UNSPECIFIED",
+        "MIB",
+        "GIB",
+        "TIB",
+        "PIB",
+        "EIB"
+      ],
+      "default": "UNIT_UNSPECIFIED"
+    },
+    "UpdateAccountBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/AccountRelationship"
+        }
+      }
+    },
+    "UpdateApplicationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateCatalogRepositoryBody": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateOrganizationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateOrganizationSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        }
+      }
+    },
+    "UpdateSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/MapSecret"
+        }
+      }
+    },
+    "UpdateUserAccountResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateUserProfileAvatarRequest": {
+      "type": "object",
+      "properties": {
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "UpdateUserProfileRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateUserProfileSettingsRequest": {
+      "type": "object",
+      "properties": {
+        "settings": {
+          "type": "object"
+        }
+      },
+      "description": "TODO: given this is more of a backend support item we may want to remove this from the public api."
+    },
+    "UpdateVolumeBody": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/VolumeDefinition"
+        }
+      }
+    },
+    "UpsertApplicationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "templateSha": {
+          "type": "string"
+        },
+        "supportedValuesSha": {
+          "type": "string"
+        }
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "UserListResponse": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/User"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "UserProfile": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "organizationId": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        },
+        "settings": {
+          "type": "object"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ValidateWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/WorkflowDefinition"
+        }
+      }
+    },
+    "ValidateWorkflowResponse": {
+      "type": "object"
+    },
+    "ValueSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "VersionGetResponse": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "Volume": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the key value of the volume in the volume map containing this\nstruct. This is normally set internally by client side code when parsing\nworkflow DSLs, but will need to be set when calling the API directly."
+        },
+        "type": {
+          "type": "string",
+          "title": "type is the kind of volume. This currently determines the lifetime of the\nvolume and the data contained within it.\nEphemeral volumes are empty upon creation and have a lifespan of the\nworkflow duration. Upon workflow completion the volume and its data are\ndeleted. Host volumes represent directories on the shared filesystems of\nthe nodes themselves. They must be pre-existing and fall under\ndirectories specified in the shared-fs-roots config property of the\nVolume service. Must be one of \"EPHEMERAL\" or \"HOST\".\nDeprecated in favor of reference"
+        },
+        "ingress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/File"
+          },
+          "description": "Ingress specifies data that should be fetched and made available within\nthe volume."
+        },
+        "egress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/File"
+          },
+          "description": "Egress specifies data that exists within the volume that should be\nexported to another storage location."
+        },
+        "path": {
+          "type": "string",
+          "title": "Path is specified for host volume types with the absolute path to the\ndirectory to mount.\nDeprecated: will be removed"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Volume reference this volume is referring to."
+        }
+      },
+      "description": "Volume is an instance of a data volume used within the scope of a workflow.\nThere are a couple different types of volumes that have different data\nretention behavior. Volumes are the means of managing data for compute\napplications to process over the course of a workflow and orchestrate\ndata movement to bring injest data into the bounds of a workflow for\ncomputation or export data generated from computation it to other storage\nlocations.\n\nTODO(cedric): deprecate type/path fields\n reserved 2, 5;\n reserved \"type\", \"path\";"
+    },
+    "VolumeDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "accessTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/definitions/VolumeStatus"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "VolumeStatus": {
+      "type": "string",
+      "enum": [
+        "VOLUME_STATUS_UNSPECIFIED",
+        "VOLUME_STATUS_ENABLED",
+        "VOLUME_STATUS_DISABLED"
+      ],
+      "default": "VOLUME_STATUS_UNSPECIFIED"
+    },
+    "VolumeTemplateValue": {
+      "type": "object",
+      "properties": {
+        "reference": {
+          "type": "string"
+        }
+      }
+    },
+    "Volumes": {
+      "type": "object",
+      "properties": {
+        "nameArgs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NameArg"
+          }
+        },
+        "nameFormat": {
+          "type": "string"
+        },
+        "maxByAccount": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "Workflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "rawSpecification": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "jobs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        },
+        "totalJobs": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "version defines the version of the workflow document."
+        },
+        "volumes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Volume"
+          },
+          "description": "volumes is a map defining volumes to use for this workflow by name.\nMap keys define the name of the volume and values are specifications\ndetailing the data volume. Volume names are used by different\ncomponents of the workflow to reference a particular volume instance."
+        },
+        "jobs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowDefinition.Job"
+          },
+          "description": "jobs is a map defining jobs to run as a part of the workflow.\nMap keys define the name of the job and values are specifications\ndetailing the compute job. Job names are used by different components\nof the workflow to reference a particular compute job instance."
+        },
+        "completed": {
+          "$ref": "#/definitions/Completed",
+          "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Annotations for the whole workflow. Currently, this is used by the\nscheduler to place jobs in a certain topology zone"
+        },
+        "defaults": {
+          "$ref": "#/definitions/Defaults"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "files is a map defining files that may be injected into volumes and jobs.\nMap keys define the name of the file and values are the file's contents.\nFiles names are used by job and volume.ingress components\nto reference a specific file."
+        },
+        "services": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Service"
+          }
+        }
+      },
+      "description": "WorkflowDefinition is the highest level unit of work for a Fuzzball cluster.\nWorkflows consist of orchestrating data volumes, container images and\ncontainer execution across a compute cluster."
+    },
+    "WorkflowDefinition.Job": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Used internally to store the job name.  If this field is present in a\ndefinition then it will be ignored in preference for the map key used in\nthe `jobs` field."
+        },
+        "image": {
+          "$ref": "#/definitions/URI",
+          "title": "Image is the URI to the container image to be used for this job.\nSupported uri formats are: \"docker://...\" and \"oras://\" for OCI\nand SIF(Singularity Image Format) images respectively.\nE.g. docker://alpine:latest"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "command is the arguments executed by the container process."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside of the job\ncontainer."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowDefinition.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "cwd allows the specification of the the working dirctory used by the job.\nThis must be an absolute path. If unset the working directory defaults\nfirst to the working directory in the OCI image config if present and\nthen to \"/\"."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "requires is a list of prerequisite jobs/services in the workflow that must be\ncompleted before this job may be started. This allows jobs within a\nworkflow to be formed into a directed acyclic graph. If requirements\nspecified by different jobs results in a cycle, the workflow will fail to\nstart.\n\nDeprecated: use the `dependsOn` field instead.\nIgnored if `dependsOn` is set.\nIf used instead of `dependsOn`, dependencies are assumed to be \"when jobN has finished\"."
+        },
+        "policy": {
+          "$ref": "#/definitions/Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        },
+        "multinode": {
+          "$ref": "#/definitions/Multinode",
+          "description": "multinode enables a job to run across multiple nodes in parallel."
+        },
+        "taskArray": {
+          "$ref": "#/definitions/TaskArray",
+          "description": "task_array enables a job to be broken up into multiple tasks that run\nconcurrently. This is useful for doing embarrassingly parallel compute\nwork."
+        },
+        "network": {
+          "$ref": "#/definitions/Network",
+          "title": "network defines if the job should run inside its own netowrk namespace"
+        },
+        "script": {
+          "type": "string",
+          "title": "shellbang script executed via command"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "args passed to above script field, can also be passed to existing command"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Dependency"
+          },
+          "description": "dependsOn is a list of concrete dependencies that must be satisfied before this job can run."
+        }
+      },
+      "description": "Job is a single compute \"step\" in a workflow.\nThere are a variety of different types of jobs that\nresult in one or more containers being spawned.\nBy default, a single container is spawned unless the\nTaskArray or Multinode fields are specified."
+    },
+    "WorkflowDefinition.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "WorkflowDefinition.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/WorkflowDefinition.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "WorkflowDefinition.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "WorkflowDefinition.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "WorkflowGatewayAttachRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "stdin": {
+          "type": "boolean"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "ws": {
+          "$ref": "#/definitions/TerminalSize"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "WorkflowGatewayAttachResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowGatewayExecRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ws": {
+          "$ref": "#/definitions/TerminalSize"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "terminal": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "WorkflowGatewayExecResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        },
+        "exitCode": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowGatewayLogCommand": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+      ],
+      "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+    },
+    "WorkflowGatewayLogResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowGatewayLogShow": {
+      "type": "object",
+      "properties": {
+        "tail": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "follow": {
+          "type": "boolean"
+        }
+      }
+    },
+    "WorkflowGatewayPortForwardResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "WorkflowIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "WorkflowPlan": {
+      "type": "object",
+      "properties": {
+        "stages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/WorkflowStage"
+          }
+        }
+      }
+    },
+    "WorkflowSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/ImageSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/ImageDecryptionSecret"
+        }
+      }
+    },
+    "WorkflowSecretsMap": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WorkflowSecret"
+          }
+        }
+      }
+    },
+    "WorkflowStage": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/WorkflowStatus"
+        },
+        "kind": {
+          "$ref": "#/definitions/StageKind"
+        },
+        "error": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "details": {
+          "type": "object"
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "WorkflowStatus": {
+      "type": "string",
+      "enum": [
+        "STAGE_STATUS_UNSPECIFIED",
+        "STAGE_STATUS_STARTED",
+        "STAGE_STATUS_FINISHED",
+        "STAGE_STATUS_FAILED",
+        "STAGE_STATUS_CANCELED"
+      ],
+      "default": "STAGE_STATUS_UNSPECIFIED",
+      "title": "- STAGE_STATUS_UNSPECIFIED: also used for pending"
+    },
+    "v1.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/CpuResource"
+        },
+        "mem": {
+          "$ref": "#/definitions/MemResource"
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "exclusive": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/submit/README.md
+++ b/submit/README.md
@@ -42,26 +42,26 @@ Below is the general format of calling the helper script using `uv`.
 uv run python submit_nextflow.py [OPTIONS] -- [nextflow_cmd]
 ```
 
-| Argument                  | Required | Default                        | Description                                                                                                                        |
-|---------------------------|----------|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| `nextflow_cmd`            | Yes      | (none)                         | The Nextflow command to run (specified after `--`).                                                                                |
-| `-c`, `--context`         | No       | (active context in config)     | Name of the Fuzzball context to use from config.yaml. Defaults to the active context in the config file.                           |
-| `-v`, `--verbose`         | No       | False                          | Dump the workflow before submitting and add debug logging.                                                                         |
-| `--fuzzball-config`       | No       | `~/.config/fuzzball/config.yaml` | Path to the Fuzzball configuration file.                                                                                         |
-| `-n`, `--dry-run`         | No       | False                          | Don't submit the workflow, just print it.                                                                                          |
-| `--job-name`              | No       | (UUID from command)            | Name of the Fuzzball workflow running the Nextflow controller job. Defaults to a UUID seeded by the full Nextflow command.         |
-| `--nextflow-work-base`    | No       | `nextflow/executions`          | Base directory for Nextflow execution paths.                                                                                       |
-| `--nf-fuzzball-version`   | No       | `0.0.1`                        | nf-fuzzball plugin version.                                                                                                        |
-| `--nextflow-version`      | No       | `25.05.0-edge`                 | Nextflow version to use in the Fuzzball job.                                                                                       |
-| `--timelimit`             | No       | `8h`                           | Timelimit for the pipeline job.                                                                                                    |
-| `--scratch-volume`        | No       | `volume://user/ephemeral`      | Ephemeral scratch volume reference.                                                                                                |
-| `--data-volume`           | No       | `volume://user/persistent`     | Persistent data volume reference.                                                                                                  |
-| `--nf-core`               | No       | False                          | Use nf-core conventions.                                                                                                           |
-| `--queue-size`            | No       | 20                             | Queue size for the Fuzzball executor (number of jobs that can be queued at once).                                                  |
-| `--plugin-base-uri`       | No       | Downloads from this repo       | Base URI for the nf-fuzzball plugin. The submission script expects to find a zip file at                                           |
-|                           |          |                                | `<plugin-base-uri>/v<version>/nf-fuzzball-<version>-stable-v<fuzzball-version>.zip`                                                |
-| `--s3-secret`             | Maybe    | (none)                         | Reference for fuzzball S3 secret used to pull the nf-fuzzball plugin if the base URI for the plugin download is a S3 URI.          |
-| `--ca-cert`               | Maybe    | (none)                         | If using a self-signed certificate for Fuzzball, the CA certificate used to sign the Fuzzball certificate is required              |
+| Argument                  | Required | Default                          | Description                                                                                                                        |
+|---------------------------|----------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `nextflow_cmd`            | Yes      | (none)                           | The Nextflow command to run (specified after `--`).                                                                                |
+| `-c`, `--context`         | No       | (active context in config)       | Name of the Fuzzball context to use from config.yaml. Defaults to the active context in the config file.                           |
+| `-v`, `--verbose`         | No       | False                            | Dump the workflow before submitting and add debug logging.                                                                         |
+| `--fuzzball-config`       | No       | `~/.config/fuzzball/config.yaml` | Path to the Fuzzball configuration file.                                                                                           |
+| `-n`, `--dry-run`         | No       | False                            | Don't submit the workflow, just print it.                                                                                          |
+| `--job-name`              | No       | (UUID from command)              | Name of the Fuzzball workflow running the Nextflow controller job. Defaults to a UUID seeded by the full Nextflow command.         |
+| `--nextflow-work-base`    | No       | `/data/nextflow/executions`      | Base directory for Nextflow execution paths in the persistent volume mounted at /data                                              |
+| `--nf-fuzzball-version`   | No       | `0.1.0`                          | nf-fuzzball plugin version.                                                                                                        |
+| `--nextflow-version`      | No       | `25.05.0-edge`                   | Nextflow version to use in the Fuzzball job.                                                                                       |
+| `--timelimit`             | No       | `8h`                             | Timelimit for the pipeline job.                                                                                                    |
+| `--scratch-volume`        | No       | `volume://user/ephemeral`        | Ephemeral scratch volume reference.                                                                                                |
+| `--data-volume`           | No       | `volume://user/persistent`       | Persistent data volume reference.                                                                                                  |
+| `--nf-core`               | No       | False                            | Use nf-core conventions.                                                                                                           |
+| `--queue-size`            | No       | 20                               | Queue size for the Fuzzball executor (number of jobs that can be queued at once).                                                  |
+| `--plugin-base-uri`       | No       | Downloads from this repo         | Base URI for the nf-fuzzball plugin. The submission script expects to find a zip file at                                           |
+|                           |          |                                  | `<plugin-base-uri>/v<version>/nf-fuzzball-<version>-stable-v<fuzzball-version>.zip`                                                |
+| `--s3-secret`             | Maybe    | (none)                           | Reference for fuzzball S3 secret used to pull the nf-fuzzball plugin if the base URI for the plugin download is a S3 URI.          |
+| `--ca-cert`               | Maybe    | (none)                           | If using a self-signed certificate for Fuzzball, the CA certificate used to sign the Fuzzball certificate is required              |
 
 ## Example Usage
 
@@ -93,4 +93,47 @@ uv run python submit_nextflow.py --job-name demux-test \
       --outdir /data/nextflow/out/demux-test-out
 ```
 
-## Using the Plugin from the Main Branch
+## Testing the Plugin from the Main Branch
+
+Build the plugin from the current working tree and push it to a
+location that is accessible via s3 or https from the Fuzzball
+cluster.
+
+```sh
+make push_dev
+```
+
+This depends on a script called `push_dev.local` you can create
+to customize where the script is pushed. It has to match the pattern
+the submission script looks for. Here is an example:
+
+```sh
+#! /bin/bash
+
+ver="${1:-none}"
+fb_ver="${2:=none}"
+if [[ "${ver}${fb_ver}" =~ none ]] ; then
+    echo "USAGE:  $0 PLUGIN_VERSION FUZZBALL_VERSION"
+    echo "        PLUGIN_VERSION and FUZZBALL_VERSION are both expected to start with a v"
+fi
+
+aws s3 cp \
+    build/distributions/nf-fuzzball-${ver}.zip \
+    s3://co-ciq-misc-support/nf-fuzzball/${ver}/nf-fuzzball-${ver}-stable-${fb_ver}.zip
+```
+
+Once the plugin has been built and pushed to an accessible location you
+can run a test with a command like this:
+
+```sh
+python submit_nextflow.py \
+    --plugin-base-uri=s3://MY_BUCKET/MY_PREFIX/nf-fuzzball  \
+    --s3-secret "secret://user/MY_S3_SECRET" \
+    -- \
+    nextflow run \
+      -with-report report.html \
+      -with-trace \
+      -with-timeline timeline.html \
+      -profile fuzzball \
+      hello
+```

--- a/submit/README.md
+++ b/submit/README.md
@@ -20,7 +20,7 @@ The following section will walk though getting your environment set up with
 
 ```sh
 uv venv
-uv pip install requests pyyaml
+uv pip install urllib3 pyyaml
 uv run python submit_nextflow.py --help
 ```
 
@@ -61,6 +61,7 @@ uv run python submit_nextflow.py [OPTIONS] -- [nextflow_cmd]
 | `--plugin-base-uri`       | No       | Downloads from this repo       | Base URI for the nf-fuzzball plugin. The submission script expects to find a zip file at                                           |
 |                           |          |                                | `<plugin-base-uri>/v<version>/nf-fuzzball-<version>-stable-v<fuzzball-version>.zip`                                                |
 | `--s3-secret`             | Maybe    | (none)                         | Reference for fuzzball S3 secret used to pull the nf-fuzzball plugin if the base URI for the plugin download is a S3 URI.          |
+| `--ca-cert`               | Maybe    | (none)                         | If using a self-signed certificate for Fuzzball, the CA certificate used to sign the Fuzzball certificate is required              |
 
 ## Example Usage
 
@@ -69,12 +70,27 @@ uv run python submit_nextflow.py [OPTIONS] -- [nextflow_cmd]
 # ~/.config/fuzzball/config.yaml
 
 fuzzball context login
+```
 
-# Submit nf-core/demultiplex workflow into Fuzzball such that each child jobs
-# runs as Fuzzball workflows
+Submit the nextflow hello-world workflow
+```sh
+uv run python submit_nextflow.py -- \
+    nextflow run \
+      -profile fuzzball \
+      -with-report report.html \
+      -with-trace \
+      -with-timeline timeline.html \
+      hello
+```
+
+Submit nf-core/demultiplex workflow into Fuzzball such that each child jobs
+runs as Fuzzball workflows
+```sh
 uv run python submit_nextflow.py --job-name demux-test \
   --nf-core -- \
     nextflow run nf-core/demultiplex \
       -profile test,fuzzball \
       --outdir /data/nextflow/out/demux-test-out
 ```
+
+## Using the Plugin from the Main Branch

--- a/submit/submit_nextflow.py
+++ b/submit/submit_nextflow.py
@@ -233,7 +233,7 @@ class MinimalFuzzballClient:
         try:
             response = self._request("GET", "/version")
             version_data = json.loads(response.data.decode('utf-8'))
-            self._fb_version = version_data["version"]
+            self._fb_version = ".".join(version_data["version"].split(".")[0:2])
             logger.info(f"Connected to Fuzzball version {self._fb_version} API server")
         except urllib3.exceptions.HTTPError as e:
             raise ValueError(f"Failed to connect to Fuzzball API: {e}")
@@ -716,7 +716,8 @@ def parse_cli() -> argparse.Namespace:
         help=(
             "Base URI for the nf-fuzzball plugin. The submission script expects to find a zip file at "
             "<plugin-base-uri>/v<version>/nf-fuzzball-v<version>-stable-v<fuzzball-version>.zip. "
-            "All version strings are expected to start with a v"
+            "All version strings are expected to start with a v. The Fuzzball version is vMAJOR.MINOR, "
+            "the nf-fuzzball version is vMAJOR.MINOR.PATCH"
             "Defaults to [%(default)s]"
         ),
     )

--- a/submit/submit_nextflow.py
+++ b/submit/submit_nextflow.py
@@ -610,7 +610,7 @@ class MinimalFuzzballClient:
             logger.info("Dry run mode: not submitting the workflow.")
             self._request("DELETE", f"/secrets/{config_secret_id}")
             if cert_secret_id:
-                elf._request("DELETE", f"/secrets/{cert_secret_id}")
+               self._request("DELETE", f"/secrets/{cert_secret_id}")
             return
         response = self._request("POST", "/workflows", data=workflow)
         response_data = json.loads(response.data.decode("utf-8"))

--- a/submit/submit_nextflow.py
+++ b/submit/submit_nextflow.py
@@ -534,8 +534,11 @@ class MinimalFuzzballClient:
             uuid.uuid5(NAMESPACE_CONTENT, nxf_fuzzball_config)
         )
 
+        # Note: the setup job uses /tmp as the cwd in order to manually create the working dir
+        #       for nextflow as part of the job. This makes sure ownership and permissions are as expected
         setup_script = textwrap.dedent(f"""\
         #! /bin/sh
+        mkdir -p {wd} || exit 1
         rm -rf $HOME/.nextflow/plugins/nf-fuzzball-{plugin_version} \\
           && mkdir -p $HOME/.nextflow/plugins/nf-fuzzball-{plugin_version} $HOME/.config/fuzzball \\
           && unzip {SCRATCH_MOUNT}/nf-fuzzball.zip -d $HOME/.nextflow/plugins/nf-fuzzball-{plugin_version} > /dev/null \\
@@ -599,7 +602,7 @@ class MinimalFuzzballClient:
                             f"/tmp/{nxf_fuzzball_config_name}": f"file://{nxf_fuzzball_config_name}"
                         },
                         "mounts": mounts,
-                        "cwd": wd,
+                        "cwd": "/tmp",
                         "script": setup_script,
                         "env": env + [f"FB_CONFIG=secret://user/{config_secret_name}"] +
                                ([f"FB_CA_CERT=secret://user/{cert_secret_name}"] if self._ca_cert_file is not None else []),

--- a/submit/submit_nextflow.py
+++ b/submit/submit_nextflow.py
@@ -542,12 +542,12 @@ class MinimalFuzzballClient:
         rm -rf $HOME/.nextflow/plugins/nf-fuzzball-{plugin_version} \\
           && mkdir -p $HOME/.nextflow/plugins/nf-fuzzball-{plugin_version} $HOME/.config/fuzzball \\
           && unzip {SCRATCH_MOUNT}/nf-fuzzball.zip -d $HOME/.nextflow/plugins/nf-fuzzball-{plugin_version} > /dev/null \\
-          && echo "$FB_CONFIG" | base64 -d > $HOME/.config/fuzzball/config.yaml \\
+          && echo "$FB_CONFIG_SECRET" | base64 -d > $HOME/.config/fuzzball/config.yaml \\
           || exit 1
 
         # Setup CA certificate if provided
-        if [ ! -z "$FB_CA_CERT" ]; then
-            echo "$FB_CA_CERT" | base64 -d > $HOME/.config/fuzzball/ca.crt || exit 1
+        if [ ! -z "$FB_CA_CERT_SECRET" ]; then
+            echo "$FB_CA_CERT_SECRET" | base64 -d > $HOME/.config/fuzzball/ca.crt || exit 1
         fi
 
         # there is only a single context in the config file so it's easy to extract the token
@@ -604,8 +604,8 @@ class MinimalFuzzballClient:
                         "mounts": mounts,
                         "cwd": "/tmp",
                         "script": setup_script,
-                        "env": env + [f"FB_CONFIG=secret://user/{config_secret_name}"] +
-                               ([f"FB_CA_CERT=secret://user/{cert_secret_name}"] if self._ca_cert_file is not None else []),
+                        "env": env + [f"FB_CONFIG_SECRET=secret://user/{config_secret_name}"] +
+                               ([f"FB_CA_CERT_SECRET=secret://user/{cert_secret_name}"] if self._ca_cert_file is not None else []),
                         "policy": {"timeout": {"execute": "5m"}},
                         "resource": {"cpu": {"cores": 1}, "memory": {"size": "1GB"}},
                     },
@@ -616,7 +616,7 @@ class MinimalFuzzballClient:
                         "mounts": mounts,
                         "cwd": wd,
                         "script": nextflow_script,
-                        "env": env + ([f"FUZZBALL_CA_CERT={home}/.config/fuzzball/ca.crt"] if self._ca_cert_file is not None else []),
+                        "env": env + ([f"FB_CA_CERT={home}/.config/fuzzball/ca.crt"] if self._ca_cert_file is not None else []),
                         "policy": {"timeout": {"execute": args.timelimit}},
                         "resource": {"cpu": {"cores": 1}, "memory": {"size": "4GB"}},
                         "requires": ["setup"],


### PR DESCRIPTION
and some other refactoring:
- factor out mount points for scratch and data into global variables.
- update CI: use tag names for artefact naming and make artefact publishing happen on a manual run for a tag or a new tag getting pushed
- documented branching and tagging procedures
- build artefacts only for vMAJOR.MINOR fuzzball versions
- use vendored openapi schemas in the repo to allow building for previous fuzzball releases