### PR TITLE
FUZZ-5311: direct login for submission script

### DIFF
--- a/submit/submit_nextflow.py
+++ b/submit/submit_nextflow.py
@@ -47,6 +47,7 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 NAMESPACE_CONTENT = uuid.UUID("71c91ef2-0f9b-47f3-988b-5725d2f67599")
 DATA_MOUNT = "/data"


### PR DESCRIPTION
The submission script can now use a direct login flow as an alternative to using an existing API token from a fuzzball cli config file (and sets up the configuration for the nf-fuzzball plugin to use the token obtained via direct login flow). Also significantly refactored the FuzzballClient class to start the process of making this into a better structured code base that will eventually become a regular installable python package.
This is also the first step in the process of allowing the nf-fuzzball plugin itself to use direct login flow to refresh its API token.