### PR TITLE
FUZZ-6536: Fixes empty body exception for patch request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,11 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.18.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.1'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 // plugin version - gradle by convention seems to not use v prefixes. That does

--- a/code-generation/groovy-okhttp-sync/ApiUtils.mustache
+++ b/code-generation/groovy-okhttp-sync/ApiUtils.mustache
@@ -163,8 +163,8 @@ class ApiUtils {
                         ? bodyParams.toString()
                         : new JsonBuilder(bodyParams, JSON_GEN).toString()
             requestBody = RequestBody.create(json, MediaType.parse(contentType ?: 'application/json'))
-        } else if (method?.toUpperCase() in ['POST', 'PUT', 'PATCH']) {
-            requestBody = RequestBody.create('{}', MediaType.parse('application/json'))
+        } else if (method?.toUpperCase() == 'PATCH') {
+            requestBody = RequestBody.create(new byte[0], MediaType.parse(contentType ?: 'application/json'))
         }
 
         Request.Builder requestBuilder = new Request.Builder()

--- a/code-generation/groovy-okhttp-sync/ApiUtils.mustache
+++ b/code-generation/groovy-okhttp-sync/ApiUtils.mustache
@@ -163,7 +163,7 @@ class ApiUtils {
                         ? bodyParams.toString()
                         : new JsonBuilder(bodyParams, JSON_GEN).toString()
             requestBody = RequestBody.create(json, MediaType.parse(contentType ?: 'application/json'))
-        } else if (method?.toUpperCase() == 'PATCH') {
+        } else if (method?.toUpperCase() in ['POST', 'PUT', 'PATCH']) {
             requestBody = RequestBody.create(new byte[0], MediaType.parse(contentType ?: 'application/json'))
         }
 

--- a/code-generation/groovy-okhttp-sync/ApiUtils.mustache
+++ b/code-generation/groovy-okhttp-sync/ApiUtils.mustache
@@ -163,6 +163,8 @@ class ApiUtils {
                         ? bodyParams.toString()
                         : new JsonBuilder(bodyParams, JSON_GEN).toString()
             requestBody = RequestBody.create(json, MediaType.parse(contentType ?: 'application/json'))
+        } else if (method?.toUpperCase() in ['POST', 'PUT', 'PATCH']) {
+            requestBody = RequestBody.create('{}', MediaType.parse('application/json'))
         }
 
         Request.Builder requestBuilder = new Request.Builder()

--- a/code-generation/groovy-okhttp-sync/ApiUtils.mustache
+++ b/code-generation/groovy-okhttp-sync/ApiUtils.mustache
@@ -164,7 +164,7 @@ class ApiUtils {
                         : new JsonBuilder(bodyParams, JSON_GEN).toString()
             requestBody = RequestBody.create(json, MediaType.parse(contentType ?: 'application/json'))
         } else if (method?.toUpperCase() in ['POST', 'PUT', 'PATCH']) {
-            requestBody = RequestBody.create(new byte[0], MediaType.parse(contentType ?: 'application/json'))
+            requestBody = RequestBody.create('{}', MediaType.parse(contentType ?: 'application/json'))
         }
 
         Request.Builder requestBuilder = new Request.Builder()

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
@@ -27,7 +27,7 @@ class FuzzballTaskHandler extends TaskHandler implements FusionAwareTask {
     private final Path wrapperFile
     private final Path outputFile
     private final Path errorFile
-    private volatile String wfId
+    @groovy.transform.PackageScope volatile String wfId
     private boolean destroyed
     private FuzzballExecutor executor
     private WorkflowServiceApi fuzzballWfService
@@ -171,8 +171,12 @@ class FuzzballTaskHandler extends TaskHandler implements FusionAwareTask {
     @Override
     protected void killTask() {
         if( !wfId ) return
-        fuzzballWfService.stopWorkflow(wfId)
-        log.trace("Killing workflow with id: ${wfId}")
+        try {
+            fuzzballWfService.stopWorkflow(wfId)
+            log.trace("Killed workflow with id: ${wfId}")
+        } catch (Exception e) {
+            log.warn("[Fuzzball Executor] Failed to stop workflow ${wfId} for task: ${task.name} | ${e.message}")
+        }
     }
 
     /**

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
@@ -30,7 +30,7 @@ class FuzzballTaskHandler extends TaskHandler implements FusionAwareTask {
     @groovy.transform.PackageScope volatile String wfId
     private boolean destroyed
     private FuzzballExecutor executor
-    private WorkflowServiceApi fuzzballWfService
+    @groovy.transform.PackageScope WorkflowServiceApi fuzzballWfService
     private String wfDefinitionYaml
     private Session session
 

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
@@ -175,7 +175,7 @@ class FuzzballTaskHandler extends TaskHandler implements FusionAwareTask {
             fuzzballWfService.stopWorkflow(wfId)
             log.trace("Killed workflow with id: ${wfId}")
         } catch (Exception e) {
-            log.warn("[Fuzzball Executor] Failed to stop workflow ${wfId} for task: ${task.name} | ${e.message}")
+            log.warn("[Fuzzball Executor] Failed to stop workflow ${wfId} for task: ${task.name}", e)
         }
     }
 

--- a/src/test/groovy/com/ciq/fuzzball/FuzzballTaskHandlerSpec.groovy
+++ b/src/test/groovy/com/ciq/fuzzball/FuzzballTaskHandlerSpec.groovy
@@ -20,16 +20,15 @@ class FuzzballTaskHandlerSpec extends Specification {
         }
         def executor = Mock(FuzzballExecutor) {
             session >> Mock(Session)
-            fuzzballWfService >> wfService
         }
-        return new FuzzballTaskHandler(task, executor)
+        def handler = new FuzzballTaskHandler(task, executor)
+        handler.fuzzballWfService = wfService
+        return handler
     }
 
     def 'killTask swallows exception when stopWorkflow fails'() {
         given:
-        def wfService = Mock(WorkflowServiceApi) {
-            stopWorkflow(_) >> { throw new IOException('simulated API failure') }
-        }
+        def wfService = Mock(WorkflowServiceApi)
         def handler = makeHandler(wfService)
         handler.wfId = 'test-workflow-id'
 
@@ -37,6 +36,7 @@ class FuzzballTaskHandlerSpec extends Specification {
         handler.killTask()
 
         then:
+        1 * wfService.stopWorkflow('test-workflow-id') >> { throw new IOException('simulated API failure') }
         noExceptionThrown()
     }
 

--- a/src/test/groovy/com/ciq/fuzzball/FuzzballTaskHandlerSpec.groovy
+++ b/src/test/groovy/com/ciq/fuzzball/FuzzballTaskHandlerSpec.groovy
@@ -1,0 +1,56 @@
+// Copyright 2025 CIQ, Inc. All rights reserved.
+package com.ciq.fuzzball
+
+import nextflow.processor.TaskRun
+import nextflow.processor.TaskConfig
+import nextflow.Session
+import java.nio.file.Path
+
+import com.ciq.fuzzball.api.WorkflowServiceApi
+
+import spock.lang.Specification
+
+class FuzzballTaskHandlerSpec extends Specification {
+
+    private FuzzballTaskHandler makeHandler(WorkflowServiceApi wfService) {
+        def taskWorkDir = Mock(Path) { resolve(_) >> Mock(Path) }
+        def task = Mock(TaskRun) {
+            workDir >> taskWorkDir
+            config >> Mock(TaskConfig) { getTime() >> null }
+        }
+        def executor = Mock(FuzzballExecutor) {
+            session >> Mock(Session)
+            fuzzballWfService >> wfService
+        }
+        return new FuzzballTaskHandler(task, executor)
+    }
+
+    def 'killTask swallows exception when stopWorkflow fails'() {
+        given:
+        def wfService = Mock(WorkflowServiceApi) {
+            stopWorkflow(_) >> { throw new IOException('simulated API failure') }
+        }
+        def handler = makeHandler(wfService)
+        handler.wfId = 'test-workflow-id'
+
+        when:
+        handler.killTask()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'killTask is a no-op when wfId is null'() {
+        given:
+        def wfService = Mock(WorkflowServiceApi)
+        def handler = makeHandler(wfService)
+        // wfId intentionally left null
+
+        when:
+        handler.killTask()
+
+        then:
+        0 * wfService.stopWorkflow(_)
+    }
+
+}


### PR DESCRIPTION
- PATCH empty body: added else if method in [POST, PUT, PATCH] to substitute {} when no body is provided in ApiUtils.mustache.
- Graceful `killTask()` in `FuzzballTaskHandler.groovy`: wrapped stopWorkflow in a try-catch that logs a warning instead of crashing the poll loop.
- Test infrastructure : added Spock, made wfId @PackageScope, and added two passing tests.