### PR TITLE
Changes groovy imports to accomodate reorg of API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:5.0.0'
     implementation 'org.yaml:snakeyaml:2.2'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.2'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ test {
 
 // plugin version - gradle by convention seems to not use v prefixes. That does
 // cause some issues in other places but we'll stick with convention
-version = '0.2.0'
+version = '0.3.0'
 
 nextflowPlugin {
     // minimum nextflow version

--- a/code-generation/schemas/fuzzball-v3.3-openapi.json
+++ b/code-generation/schemas/fuzzball-v3.3-openapi.json
@@ -1,0 +1,10328 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Fuzzball API",
+    "version": "3.0",
+    "contact": {
+      "name": "CtrlIQ, Inc",
+      "url": "https://ciq.com",
+      "email": "info@ciq.com"
+    }
+  },
+  "tags": [
+    {
+      "name": "AccountService"
+    },
+    {
+      "name": "AdminApplicationService"
+    },
+    {
+      "name": "AdminAuthService"
+    },
+    {
+      "name": "AdminCentralConfigService"
+    },
+    {
+      "name": "AdminClusterService"
+    },
+    {
+      "name": "AdminClusterRegistrationService"
+    },
+    {
+      "name": "AdminDebugService"
+    },
+    {
+      "name": "AdminProvisionerService"
+    },
+    {
+      "name": "AdminSchedulerService"
+    },
+    {
+      "name": "AdminSecretService"
+    },
+    {
+      "name": "AdminSetupService"
+    },
+    {
+      "name": "AdminStorageClassService"
+    },
+    {
+      "name": "AdminStorageDriverService"
+    },
+    {
+      "name": "AdminUserService"
+    },
+    {
+      "name": "AdminWorkflowService"
+    },
+    {
+      "name": "ApplicationService"
+    },
+    {
+      "name": "ClusterService"
+    },
+    {
+      "name": "LocalAuthService"
+    },
+    {
+      "name": "NodeService"
+    },
+    {
+      "name": "OrganizationService"
+    },
+    {
+      "name": "ProvisionerService"
+    },
+    {
+      "name": "SecretService"
+    },
+    {
+      "name": "StorageClassService"
+    },
+    {
+      "name": "StorageVolumeService"
+    },
+    {
+      "name": "UserService"
+    },
+    {
+      "name": "VersionService"
+    },
+    {
+      "name": "WorkflowService"
+    },
+    {
+      "name": "WorkflowGatewayService"
+    },
+    {
+      "name": "WorkflowGenerateService"
+    }
+  ],
+  "basePath": "/v3",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/accounts": {
+      "get": {
+        "operationId": "ListAccounts",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListAccountsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "showUserAccounts",
+            "description": "Only valid for org/platform owners. By default all users/owners will only\nsee their own user group (auto-created personal group).\nNOTE: \"user account\" refers to a personal group automatically created for each user.\nThis flag controls whether to show these personal groups or only collaborative groups.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateAccountRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/update-user-account": {
+      "get": {
+        "operationId": "UpdateUserAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UpdateUserAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}": {
+      "get": {
+        "operationId": "GetAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AccountService.UpdateAccountBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members": {
+      "get": {
+        "operationId": "ListAccountMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "description": " - ACCOUNT_MEMBER: ACCOUNT_MEMBER indicates a user is a member of the group (deprecated, prefer GROUP_MEMBER)\n - GROUP_MEMBER: GROUP_MEMBER indicates a user is a member of the group\n - ACCOUNT_OWNER: ACCOUNT_OWNER indicates a user owns/administers the group (deprecated, prefer GROUP_OWNER)\n - GROUP_OWNER: GROUP_OWNER indicates a user owns/administers the group",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "GROUP_MEMBER",
+              "ACCOUNT_OWNER",
+              "GROUP_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "post": {
+        "operationId": "AddAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AccountService.AddAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AccountService.UpdateAccountMemberBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/members/{userId}": {
+      "delete": {
+        "operationId": "RemoveAccountMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "description": " - ACCOUNT_MEMBER: ACCOUNT_MEMBER indicates a user is a member of the group (deprecated, prefer GROUP_MEMBER)\n - GROUP_MEMBER: GROUP_MEMBER indicates a user is a member of the group\n - ACCOUNT_OWNER: ACCOUNT_OWNER indicates a user owns/administers the group (deprecated, prefer GROUP_OWNER)\n - GROUP_OWNER: GROUP_OWNER indicates a user owns/administers the group",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ACCOUNT_MEMBER",
+              "GROUP_MEMBER",
+              "ACCOUNT_OWNER",
+              "GROUP_OWNER"
+            ],
+            "default": "ACCOUNT_MEMBER"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/accounts/{id}/token": {
+      "get": {
+        "operationId": "SelectAccount",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SelectAccountResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AccountService"
+        ]
+      }
+    },
+    "/admin/application/{id}:disable": {
+      "post": {
+        "operationId": "AdminDisableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminApplicationService"
+        ]
+      }
+    },
+    "/admin/application/{id}:enable": {
+      "post": {
+        "operationId": "AdminEnableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminApplicationService"
+        ]
+      }
+    },
+    "/admin/catalog/repositories": {
+      "get": {
+        "operationId": "AdminListCatalogRepositories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminListCatalogRepositoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "AdminApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "AdminAddCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AddCatalogRepositoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminApplicationService"
+        ]
+      }
+    },
+    "/admin/catalog/repositories/{id}": {
+      "get": {
+        "operationId": "AdminGetCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "AdminDeleteCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminApplicationService"
+        ]
+      }
+    },
+    "/admin/catalog/repositories/{id}:reload": {
+      "post": {
+        "operationId": "AdminReloadCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ReloadCatalogRepositoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminApplicationService"
+        ]
+      }
+    },
+    "/admin/centralconfig": {
+      "get": {
+        "operationId": "GetConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CentralConfig"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "revision",
+            "description": "0 for latest",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "uint64"
+          }
+        ],
+        "tags": [
+          "AdminCentralConfigService"
+        ]
+      },
+      "post": {
+        "operationId": "SetConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CentralConfig"
+            }
+          }
+        ],
+        "tags": [
+          "AdminCentralConfigService"
+        ]
+      }
+    },
+    "/admin/centralconfig/revisions": {
+      "get": {
+        "operationId": "ListConfigRevisions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListCentralConfigRevisions"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "AdminCentralConfigService"
+        ]
+      }
+    },
+    "/admin/cluster/jobs": {
+      "get": {
+        "operationId": "AdminGetJobsSummary",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminGetJobsSummaryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminWorkflowService"
+        ]
+      }
+    },
+    "/admin/cluster/registration": {
+      "post": {
+        "operationId": "RegisterCluster",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.RegisterClusterResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.RegisterClusterRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminClusterRegistrationService"
+        ]
+      }
+    },
+    "/admin/cluster/registration/configuration:generate": {
+      "get": {
+        "operationId": "GenerateClusterRegistrationConfiguration",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GenerateClusterRegistrationConfigurationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "AdminClusterRegistrationService"
+        ]
+      }
+    },
+    "/admin/cluster/secrets": {
+      "get": {
+        "operationId": "ListClusterSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminSecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateClusterSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminSecretService"
+        ]
+      }
+    },
+    "/admin/cluster/secrets/{id}": {
+      "get": {
+        "operationId": "GetClusterSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminSecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteClusterSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminSecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateClusterSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminSecretService.UpdateClusterSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "AdminSecretService"
+        ]
+      }
+    },
+    "/admin/cluster/workflows": {
+      "get": {
+        "operationId": "AdminGetWorkflowsSummary",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminGetWorkflowsSummaryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminWorkflowService"
+        ]
+      }
+    },
+    "/admin/cluster/{id}": {
+      "get": {
+        "operationId": "AdminGetCluster",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Cluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminClusterService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteCluster",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ClusterIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminClusterService"
+        ]
+      }
+    },
+    "/admin/clusters": {
+      "get": {
+        "operationId": "AdminListClusters",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListClustersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminClusterService"
+        ]
+      }
+    },
+    "/admin/debug/fuzzball/dump": {
+      "get": {
+        "operationId": "GetFuzzballClusterDump",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/fuzzball.api.v3.Artifact"
+                },
+                "error": {
+                  "$ref": "#/definitions/google.rpc.Status"
+                }
+              },
+              "title": "Stream result of fuzzball.api.v3.Artifact"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminDebugService"
+        ]
+      }
+    },
+    "/admin/debug/services/{serviceName}/logs": {
+      "get": {
+        "operationId": "GetServiceLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/fuzzball.api.v3.LogEntry"
+                },
+                "error": {
+                  "$ref": "#/definitions/google.rpc.Status"
+                }
+              },
+              "title": "Stream result of fuzzball.api.v3.LogEntry"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "serviceName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "sinceDuration",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "tail",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "follow",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "ignoreErrors",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "minLogLevel",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "traceId",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminDebugService"
+        ]
+      }
+    },
+    "/admin/drivers": {
+      "get": {
+        "operationId": "ListDrivers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListDriversResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminStorageDriverService"
+        ]
+      },
+      "post": {
+        "operationId": "InstallDriver",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.DriverIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.InstallDriverRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminStorageDriverService"
+        ]
+      }
+    },
+    "/admin/drivers/{id}": {
+      "get": {
+        "operationId": "GetDriver",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.DriverInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminStorageDriverService"
+        ]
+      },
+      "delete": {
+        "operationId": "UninstallDriver",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.DriverIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminStorageDriverService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateDriver",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.DriverIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminStorageDriverService.UpdateDriverBody"
+            }
+          }
+        ],
+        "tags": [
+          "AdminStorageDriverService"
+        ]
+      }
+    },
+    "/admin/login": {
+      "get": {
+        "operationId": "AdminLoginStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminLoginStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "AdminAuthService"
+        ]
+      },
+      "post": {
+        "operationId": "AdminLogin",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminLoginResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminLoginRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminAuthService"
+        ]
+      }
+    },
+    "/admin/provisioner/definitions": {
+      "get": {
+        "operationId": "AdminListProvisionerDefinitions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListProvisionerDefinitionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminProvisionerService"
+        ]
+      }
+    },
+    "/admin/provisioner/definitions/{id}": {
+      "get": {
+        "operationId": "AdminGetProvisionerDefinition",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ProvisionerDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminProvisionerService"
+        ]
+      }
+    },
+    "/admin/provisioner/definitions/{id}/reset-resource": {
+      "post": {
+        "operationId": "AdminResetProvisionerDefinitionResource",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ProvisionerDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminProvisionerService"
+        ]
+      }
+    },
+    "/admin/provisioner/instances": {
+      "get": {
+        "operationId": "ListProvisionerInstances",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminListProvisionerInstancesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminProvisionerService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateProvisionerInstances",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminCreateProvisionerInstancesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminCreateProvisionerInstancesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminProvisionerService"
+        ]
+      }
+    },
+    "/admin/provisioner/instances/{id}": {
+      "get": {
+        "operationId": "GetProvisionerInstance",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminProvisionerInstance"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminProvisionerService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteProvisionerInstance",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminDeleteProvisionerInstanceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminProvisionerService"
+        ]
+      }
+    },
+    "/admin/setup/provision/definition": {
+      "post": {
+        "operationId": "CreateDefaultResourceDefinition",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateDefaultResourceDefinitionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateDefaultResourceDefinitionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminSetupService"
+        ]
+      }
+    },
+    "/admin/setup/storage": {
+      "post": {
+        "operationId": "CreateDefaultStorage",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateDefaultStorageResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateDefaultStorageRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminSetupService"
+        ]
+      }
+    },
+    "/admin/storage-classes": {
+      "get": {
+        "operationId": "AdminListStorageClasses",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListStorageClassesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageClassIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateStorageClassRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      }
+    },
+    "/admin/storage-classes/{id}": {
+      "get": {
+        "operationId": "AdminGetStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageClassInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageClassIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageClassIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminStorageClassService.UpdateStorageClassBody"
+            }
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      }
+    },
+    "/admin/storage-classes/{id}:describe": {
+      "get": {
+        "operationId": "DescribeStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.DescribeStorageClassResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      }
+    },
+    "/admin/storage-classes/{id}:disable": {
+      "patch": {
+        "operationId": "DisableStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageClassIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminStorageClassService.DisableStorageClassBody"
+            }
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      }
+    },
+    "/admin/storage-classes/{id}:enable": {
+      "patch": {
+        "operationId": "EnableStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageClassIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminStorageClassService.EnableStorageClassBody"
+            }
+          }
+        ],
+        "tags": [
+          "AdminStorageClassService"
+        ]
+      }
+    },
+    "/admin/users": {
+      "get": {
+        "operationId": "ListUsers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminListUsersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminUserService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminUserIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminCreateUserRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdminUserService"
+        ]
+      }
+    },
+    "/admin/users/{id}": {
+      "get": {
+        "operationId": "GetUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminUser"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminUserService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminUserIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdminUserService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminUser"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminUserService.UpdateUserBody"
+            }
+          }
+        ],
+        "tags": [
+          "AdminUserService"
+        ]
+      }
+    },
+    "/admin/workflows/running-jobs": {
+      "get": {
+        "operationId": "AdminListRunningJobs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AdminListRunningJobsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "AdminWorkflowService"
+        ]
+      }
+    },
+    "/applications": {
+      "get": {
+        "operationId": "ListApplications",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListApplicationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "statsScope",
+            "description": " - USAGE_STATS_SCOPE_ALL: Usage across all accounts/organizations\n - USAGE_STATS_SCOPE_ACCOUNT: Usage within the user's account\n - USAGE_STATS_SCOPE_ORGANIZATION: Usage within the user's organization",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "USAGE_STATS_SCOPE_UNSPECIFIED",
+              "USAGE_STATS_SCOPE_ALL",
+              "USAGE_STATS_SCOPE_ACCOUNT",
+              "USAGE_STATS_SCOPE_ORGANIZATION"
+            ],
+            "default": "USAGE_STATS_SCOPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/categories": {
+      "get": {
+        "operationId": "ListApplicationCategories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListApplicationCategoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/usage-stats": {
+      "get": {
+        "operationId": "GetApplicationUsageStats",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetApplicationUsageStatsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "description": "\"view_count\", \"run_count\", \"edited_count\", \"copy_count\", \"unique_users\", \"last_used_time\"",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "scope",
+            "description": " - USAGE_STATS_SCOPE_ALL: Usage across all accounts/organizations\n - USAGE_STATS_SCOPE_ACCOUNT: Usage within the user's account\n - USAGE_STATS_SCOPE_ORGANIZATION: Usage within the user's organization",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "USAGE_STATS_SCOPE_UNSPECIFIED",
+              "USAGE_STATS_SCOPE_ALL",
+              "USAGE_STATS_SCOPE_ACCOUNT",
+              "USAGE_STATS_SCOPE_ORGANIZATION"
+            ],
+            "default": "USAGE_STATS_SCOPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "operationId": "GetApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "trackView",
+            "description": "optional, set to true to track as a \"viewed\" event for usage stats",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationService.UpdateApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:bundle": {
+      "get": {
+        "operationId": "GetApplicationBundle",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetApplicationBundleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "excludedParts",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "TEMPLATE",
+                "VALUES",
+                "METADATA"
+              ]
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "trackUsage",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:disable": {
+      "put": {
+        "operationId": "DisableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:enable": {
+      "put": {
+        "operationId": "EnableApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:render": {
+      "post": {
+        "operationId": "RenderApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationService.RenderApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications/{id}:upsert": {
+      "patch": {
+        "operationId": "UpsertApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationService.UpsertApplicationBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:copy": {
+      "post": {
+        "operationId": "CopyApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Application"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CopyApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:render": {
+      "post": {
+        "operationId": "RenderApplicationTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.RenderApplicationTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.RenderApplicationTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/applications:start": {
+      "post": {
+        "operationId": "StartApplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StartApplicationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/auth/local/login": {
+      "get": {
+        "operationId": "LoginStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.LocalLoginStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "LocalAuthService"
+        ]
+      },
+      "post": {
+        "operationId": "Login",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.LocalLoginResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.LocalLoginRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LocalAuthService"
+        ]
+      }
+    },
+    "/catalog/repositories": {
+      "get": {
+        "operationId": "ListCatalogRepositories",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListCatalogRepositoriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "post": {
+        "operationId": "AddCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AddCatalogRepositoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories/{id}": {
+      "get": {
+        "operationId": "GetCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CatalogRepository"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CatalogRepositorySummary"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationService.UpdateCatalogRepositoryBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories/{id}:reload": {
+      "post": {
+        "operationId": "ReloadCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ReloadCatalogRepositoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ApplicationService.ReloadCatalogRepositoryBody"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/repositories:import": {
+      "post": {
+        "operationId": "ImportCatalogRepository",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ImportCatalogRepositoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ImportCatalogRepositoryRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/catalog/sync:updateSchedule": {
+      "post": {
+        "operationId": "ScheduleCatalogSync",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ScheduleCatalogSyncRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ApplicationService"
+        ]
+      }
+    },
+    "/cluster/{id}": {
+      "get": {
+        "operationId": "GetCluster",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Cluster"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/clusters": {
+      "get": {
+        "operationId": "ListClusters",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListClustersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ClusterService"
+        ]
+      }
+    },
+    "/nodes": {
+      "get": {
+        "operationId": "ListNodes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListNodesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "NodeService"
+        ]
+      }
+    },
+    "/nodes/{id}": {
+      "get": {
+        "operationId": "GetNode",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetNodeInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "NodeService"
+        ]
+      }
+    },
+    "/organization": {
+      "get": {
+        "operationId": "GetOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganization",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Organization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UpdateOrganizationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members": {
+      "get": {
+        "operationId": "ListOrganizationMembers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "post": {
+        "summary": "Deprecated: Use AddOrganizationMemberV2 to receive generated password",
+        "operationId": "AddOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AddOrganizationMemberRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members/{id}": {
+      "delete": {
+        "operationId": "RemoveOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relationship",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "ORGANIZATION_MEMBER",
+              "ORGANIZATION_OWNER"
+            ],
+            "default": "ORGANIZATION_MEMBER"
+          },
+          {
+            "name": "clusterAdmin",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "updateRelationship",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/members/{id}/password": {
+      "post": {
+        "operationId": "ResetOrganizationMemberPassword",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ResetOrganizationMemberPasswordResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.OrganizationService.ResetOrganizationMemberPasswordBody"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/organization/secrets": {
+      "get": {
+        "operationId": "ListOrganizationSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/organization/secrets/{id}": {
+      "get": {
+        "operationId": "GetOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateOrganizationSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretService.UpdateOrganizationSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/profile": {
+      "get": {
+        "operationId": "GetUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "UserService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateUserProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UpdateUserProfileRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/avatar": {
+      "patch": {
+        "operationId": "UpdateUserProfileAvatar",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UpdateUserProfileAvatarRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/password": {
+      "post": {
+        "operationId": "ChangeUserPassword",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ChangeUserPasswordResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ChangeUserPasswordRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/profile/settings": {
+      "patch": {
+        "summary": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+        "operationId": "UpdateUserProfileSettings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UserProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "TODO: given this is more of a backend support item we may want to remove this from the public api.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UpdateUserProfileSettingsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/provisioner/definitions": {
+      "get": {
+        "operationId": "ListProvisionerDefinitions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListProvisionerDefinitionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionerService"
+        ]
+      }
+    },
+    "/provisioner/definitions/{id}": {
+      "get": {
+        "operationId": "GetProvisionerDefinition",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ProvisionerDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ProvisionerService"
+        ]
+      }
+    },
+    "/secrets": {
+      "get": {
+        "operationId": "ListSecrets",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "put": {
+        "operationId": "CreateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateSecretRequest"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/secrets/{id}": {
+      "get": {
+        "operationId": "GetSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Secret"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      },
+      "patch": {
+        "operationId": "UpdateSecret",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SecretService.UpdateSecretBody"
+            }
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
+    },
+    "/storage-classes": {
+      "get": {
+        "operationId": "ListStorageClasses",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListStorageClassesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/storage-classes/{id}": {
+      "get": {
+        "operationId": "GetStorageClass",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageClassInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageClassService"
+        ]
+      }
+    },
+    "/stream/workflow/attach": {
+      "post": {
+        "operationId": "WorkflowGatewayAttach",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/fuzzball.api.v3.WorkflowGatewayAttachResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/google.rpc.Status"
+                }
+              },
+              "title": "Stream result of fuzzball.api.v3.WorkflowGatewayAttachResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.WorkflowGatewayAttachRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/exec": {
+      "post": {
+        "operationId": "WorkflowGatewayExec",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/fuzzball.api.v3.WorkflowGatewayExecResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/google.rpc.Status"
+                }
+              },
+              "title": "Stream result of fuzzball.api.v3.WorkflowGatewayExecResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.WorkflowGatewayExecRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/stream/workflow/generate": {
+      "post": {
+        "operationId": "GenerateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/fuzzball.api.v3.GenerateWorkflowServerMessage"
+                },
+                "error": {
+                  "$ref": "#/definitions/google.rpc.Status"
+                }
+              },
+              "title": "Stream result of fuzzball.api.v3.GenerateWorkflowServerMessage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GenerateWorkflowClientMessage"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowGenerateService"
+        ]
+      }
+    },
+    "/v2/organization/members": {
+      "post": {
+        "summary": "Returns full response including generated password when applicable",
+        "operationId": "AddOrganizationMemberV2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AddOrganizationMemberResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.AddOrganizationMemberRequest"
+            }
+          }
+        ],
+        "tags": [
+          "OrganizationService"
+        ]
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Get the fuzzball agent version",
+        "operationId": "VersionGet",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.VersionGetResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "VersionService"
+        ]
+      }
+    },
+    "/volumes": {
+      "get": {
+        "operationId": "ListVolumes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListVolumesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "post": {
+        "operationId": "CreateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.CreateVolumeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}": {
+      "get": {
+        "operationId": "GetVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.VolumeInfoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "delete": {
+        "operationId": "DeleteVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      },
+      "put": {
+        "operationId": "UpdateVolume",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.VolumeIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageVolumeService.UpdateVolumeBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/volumes/{id}:set-status": {
+      "patch": {
+        "operationId": "SetVolumeStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.SetVolumeStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StorageVolumeService.SetVolumeStatusBody"
+            }
+          }
+        ],
+        "tags": [
+          "StorageVolumeService"
+        ]
+      }
+    },
+    "/workflows": {
+      "get": {
+        "summary": "List workflows",
+        "operationId": "ListWorkflows",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ListWorkflowsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "status",
+            "description": "Deprecated as this was not used and we need ability to filter by multiple statuses.\n\n - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "requestedStatuses",
+            "description": "Allows multiple statuses to be requested.\n\n - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "STAGE_STATUS_UNSPECIFIED",
+                "STAGE_STATUS_STARTED",
+                "STAGE_STATUS_FINISHED",
+                "STAGE_STATUS_FAILED",
+                "STAGE_STATUS_CANCELED"
+              ]
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "scope",
+            "description": " - SCOPE_USER: SCOPE_USER returns workflows for the user within the currently selected group\n - SCOPE_ACCOUNT: SCOPE_ACCOUNT returns workflows for the group (deprecated, prefer SCOPE_GROUP)\n - SCOPE_GROUP: SCOPE_GROUP returns workflows for the entire group",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SCOPE_UNSPECIFIED",
+              "SCOPE_USER",
+              "SCOPE_ACCOUNT",
+              "SCOPE_GROUP"
+            ],
+            "default": "SCOPE_UNSPECIFIED"
+          },
+          {
+            "name": "aipFilter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "summary": "Start a new workflow",
+        "operationId": "StartWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.StartWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary": {
+      "get": {
+        "summary": "Get a summary of workflows",
+        "operationId": "GetWorkflowsSummary",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetWorkflowsSummaryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "userWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "otherOwnerWorkflowPageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary/account-owner/details": {
+      "get": {
+        "summary": "Get workflow summary details for group owners\nNOTE: \"Account owner\" refers to group owners (deprecated terminology).",
+        "operationId": "GetAccountOwnerWorkflowsSummaryDetails",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetAccountOwnerWorkflowsSummaryDetailsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "requestedStatus",
+            "description": " - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/summary/account-owner/users": {
+      "get": {
+        "summary": "Get workflow users for group owners\nNOTE: \"Account owner\" refers to group owners (deprecated terminology).",
+        "operationId": "GetAccountOwnerWorkflowsUsers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetAccountOwnerWorkflowsUsersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "daysPrior",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "requestedStatus",
+            "description": " - STAGE_STATUS_UNSPECIFIED: also used for pending",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_STATUS_UNSPECIFIED",
+              "STAGE_STATUS_STARTED",
+              "STAGE_STATUS_FINISHED",
+              "STAGE_STATUS_FAILED",
+              "STAGE_STATUS_CANCELED"
+            ],
+            "default": "STAGE_STATUS_UNSPECIFIED"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}": {
+      "get": {
+        "summary": "Get details on a workflow",
+        "operationId": "GetWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.Workflow"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners": {
+      "get": {
+        "operationId": "ListWorkflowOwners",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.UserListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      },
+      "post": {
+        "operationId": "AddWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.WorkflowService.AddWorkflowOwnerBody"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}/owners/{userId}": {
+      "delete": {
+        "operationId": "RemoveWorkflowOwner",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.User"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:activity": {
+      "get": {
+        "summary": "Get stage events (activity log) for a workflow",
+        "operationId": "GetStageEvents",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetStageEventsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "stageId",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "tail",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "kindFilter",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "STAGE_KIND_UNSPECIFIED",
+              "STAGE_KIND_WORKFLOW",
+              "STAGE_KIND_JOB",
+              "STAGE_KIND_FILE",
+              "STAGE_KIND_IMAGE",
+              "STAGE_KIND_VOLUME",
+              "STAGE_KIND_COMPLETED",
+              "STAGE_KIND_SERVICE"
+            ],
+            "default": "STAGE_KIND_UNSPECIFIED"
+          },
+          {
+            "name": "stageName",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:log": {
+      "get": {
+        "operationId": "WorkflowGatewayLog",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/fuzzball.api.v3.WorkflowGatewayLogResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/google.rpc.Status"
+                }
+              },
+              "title": "Stream result of fuzzball.api.v3.WorkflowGatewayLogResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "show.tail",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "show.follow",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "command",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+            ],
+            "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+          },
+          {
+            "name": "name",
+            "description": "Name of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "rank",
+            "description": "Rank of the container to execute the command in.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "WorkflowGatewayService"
+        ]
+      }
+    },
+    "/workflows/{id}:status": {
+      "get": {
+        "summary": "Get the status on a workflow",
+        "operationId": "GetWorkflowStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.GetWorkflowStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows/{id}:stop": {
+      "patch": {
+        "summary": "Stop a workflow",
+        "operationId": "StopWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.WorkflowIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:score": {
+      "patch": {
+        "summary": "ScoreWorkflow returns the score for a workflow definition.",
+        "operationId": "ScoreWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ScoreWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ScoreWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    },
+    "/workflows:validate": {
+      "post": {
+        "summary": "Validate a workflow definition",
+        "operationId": "ValidateWorkflow",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ValidateWorkflowResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/google.rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fuzzball.api.v3.ValidateWorkflowRequest"
+            }
+          }
+        ],
+        "tags": [
+          "WorkflowService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "fuzzball.api.v3.Account": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "description": "Account represents a group within an organization.\nNOTE: The term \"Account\" is deprecated in favor of \"Group\". This message\nrepresents a collaborative group of users within an organization, not to be\nconfused with user authentication credentials. The name remains \"Account\"\nfor backwards compatibility with existing API clients."
+    },
+    "fuzzball.api.v3.AccountOwnerWorkflowsSummary": {
+      "type": "object",
+      "properties": {
+        "currentWorkflowsStarted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentWorkflowsPending": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "averageWorkflowPendingMilliseconds": {
+          "type": "number",
+          "format": "double"
+        },
+        "workflowsCompleted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "totalAccountUsers": {
+          "type": "integer",
+          "format": "int32",
+          "title": "total_account_users is the total number of users in the group"
+        }
+      },
+      "description": "AccountOwnerWorkflowsSummary provides workflow statistics for group owners.\nNOTE: \"Account owner\" refers to group owners (deprecated terminology)."
+    },
+    "fuzzball.api.v3.AccountOwnerWorkflowsSummaryDetails": {
+      "type": "object",
+      "properties": {
+        "workflowsResponse": {
+          "$ref": "#/definitions/fuzzball.api.v3.SummarizedWorkflowResponse"
+        }
+      },
+      "description": "AccountOwnerWorkflowsSummaryDetails provides detailed workflow info for group owners.\nNOTE: \"Account owner\" refers to group owners (deprecated terminology)."
+    },
+    "fuzzball.api.v3.AccountRelationship": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT_MEMBER",
+        "GROUP_MEMBER",
+        "ACCOUNT_OWNER",
+        "GROUP_OWNER"
+      ],
+      "default": "ACCOUNT_MEMBER",
+      "description": "AccountRelationship defines a user's role within a group.\nNOTE: The term \"Account\" is deprecated. This enum represents group membership\nrelationships. Use GROUP_MEMBER and GROUP_OWNER when these values are added\nin a future API version.\n\n - ACCOUNT_MEMBER: ACCOUNT_MEMBER indicates a user is a member of the group (deprecated, prefer GROUP_MEMBER)\n - GROUP_MEMBER: GROUP_MEMBER indicates a user is a member of the group\n - ACCOUNT_OWNER: ACCOUNT_OWNER indicates a user owns/administers the group (deprecated, prefer GROUP_OWNER)\n - GROUP_OWNER: GROUP_OWNER indicates a user owns/administers the group"
+    },
+    "fuzzball.api.v3.AccountService.AddAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/fuzzball.api.v3.AccountRelationship"
+        }
+      }
+    },
+    "fuzzball.api.v3.AccountService.UpdateAccountBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AccountService.UpdateAccountMemberBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/fuzzball.api.v3.AccountRelationship"
+        }
+      }
+    },
+    "fuzzball.api.v3.AddCatalogRepositoryRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        }
+      }
+    },
+    "fuzzball.api.v3.AddOrganizationMemberRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "relationship": {
+          "$ref": "#/definitions/fuzzball.api.v3.OrganizationRelationship"
+        },
+        "password": {
+          "type": "string"
+        },
+        "requireUpdatePassword": {
+          "type": "boolean",
+          "title": "true = force password change on next login"
+        },
+        "clusterAdmin": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.AddOrganizationMemberResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/fuzzball.api.v3.User"
+        },
+        "generatedPassword": {
+          "type": "string",
+          "title": "Only populated when password was auto-generated"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminCreateProvisionerInstancesRequest": {
+      "type": "object",
+      "properties": {
+        "definitionId": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "ttl": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "backendDirectives": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminCreateProvisionerInstancesResponse": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transactionId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminCreateUserRequest": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminDeleteProvisionerInstanceResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminGetJobsSummaryResponse": {
+      "type": "object",
+      "properties": {
+        "jobsSummary": {
+          "$ref": "#/definitions/fuzzball.api.v3.AdminJobsSummary"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminGetWorkflowsSummaryResponse": {
+      "type": "object",
+      "properties": {
+        "workflowsSummary": {
+          "$ref": "#/definitions/fuzzball.api.v3.AdminWorkflowsSummary"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminJobsSummary": {
+      "type": "object",
+      "properties": {
+        "jobsExecuted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "jobsFailed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentJobsStarted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentJobsPending": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "averageJobExecutionTime": {
+          "type": "number",
+          "format": "double"
+        },
+        "maxJobExecutionTime": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminListCatalogRepositoriesResponse": {
+      "type": "object",
+      "properties": {
+        "repositories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.CatalogRepository"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminListProvisionerInstancesResponse": {
+      "type": "object",
+      "properties": {
+        "instances": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.AdminProvisionerInstance"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminListRunningJobsResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.AdminWorkflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminListUsersResponse": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.AdminUser"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminLoginRequest": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminLoginResponse": {
+      "type": "object",
+      "properties": {
+        "jwt": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminLoginStatusResponse": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "validToken": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminProvisionerInstance": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "definitionId": {
+          "type": "string"
+        },
+        "state": {
+          "$ref": "#/definitions/fuzzball.api.v3.AdminProvisionerInstanceState"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "deleteTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminProvisionerInstanceState": {
+      "type": "string",
+      "enum": [
+        "ADMIN_PROVISIONER_INSTANCE_STATE_UNSPECIFIED",
+        "ADMIN_PROVISIONER_INSTANCE_STATE_CREATING",
+        "ADMIN_PROVISIONER_INSTANCE_STATE_CREATED",
+        "ADMIN_PROVISIONER_INSTANCE_STATE_DELETING",
+        "ADMIN_PROVISIONER_INSTANCE_STATE_DELETED",
+        "ADMIN_PROVISIONER_INSTANCE_STATE_ERROR"
+      ],
+      "default": "ADMIN_PROVISIONER_INSTANCE_STATE_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.AdminSecretService.UpdateClusterSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/fuzzball.api.v3.ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/fuzzball.api.v3.S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/fuzzball.api.v3.HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/fuzzball.api.v3.MapSecret"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminStorageClassService.DisableStorageClassBody": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.AdminStorageClassService.EnableStorageClassBody": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.AdminStorageClassService.UpdateStorageClassBody": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminStorageDriverService.UpdateDriverBody": {
+      "type": "object",
+      "properties": {
+        "driver": {
+          "$ref": "#/definitions/fuzzball.api.v3.DriverDefinition"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminUser": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastLoginTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminUserIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminUserService.UpdateUserBody": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminWorkflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowStatus"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "rawSpecification": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "jobs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.AdminWorkflowStage"
+          }
+        },
+        "totalJobs": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminWorkflowStage": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowStatus"
+        },
+        "kind": {
+          "$ref": "#/definitions/fuzzball.api.v3.StageKind"
+        },
+        "error": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "details": {
+          "type": "object"
+        },
+        "indexOrder": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "workflowId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.AdminWorkflowsSummary": {
+      "type": "object",
+      "properties": {
+        "workflowsExecuted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "workflowsFailed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentWorkflowsStarted": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentWorkflowsPending": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "averageWorkflowPendingMilliseconds": {
+          "type": "number",
+          "format": "double"
+        },
+        "averageWorkflowExecutionTime": {
+          "type": "number",
+          "format": "double"
+        },
+        "maxWorkflowExecutionTime": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "fuzzball.api.v3.Application": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/fuzzball.api.v3.SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "templateSha": {
+          "type": "string"
+        },
+        "supportedValueSha": {
+          "type": "string"
+        },
+        "createdBy": {
+          "type": "string"
+        },
+        "createdByEmail": {
+          "type": "string"
+        },
+        "featured": {
+          "type": "boolean"
+        },
+        "keyArt": {
+          "type": "string",
+          "format": "byte"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.ApplicationBundlePart": {
+      "type": "string",
+      "enum": [
+        "TEMPLATE",
+        "VALUES",
+        "METADATA"
+      ],
+      "default": "TEMPLATE"
+    },
+    "fuzzball.api.v3.ApplicationCategory": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ApplicationMetadata": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "featured": {
+          "type": "boolean"
+        },
+        "keyArt": {
+          "type": "string",
+          "format": "byte"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "viewCount": {
+          "type": "string",
+          "format": "int64",
+          "title": "usage stats"
+        },
+        "runCount": {
+          "type": "string",
+          "format": "int64"
+        },
+        "editedCount": {
+          "type": "string",
+          "format": "int64"
+        },
+        "copyCount": {
+          "type": "string",
+          "format": "int64"
+        },
+        "uniqueUsers": {
+          "type": "string",
+          "format": "int64"
+        },
+        "lastUsedTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.ApplicationOwnerKind": {
+      "type": "string",
+      "enum": [
+        "GROUP",
+        "ACCOUNT",
+        "ORGANIZATION",
+        "PROVIDER"
+      ],
+      "default": "GROUP",
+      "title": "- GROUP: default\n - ACCOUNT: deprecated alias for GROUP\n - ORGANIZATION: must be an organization owner to use\n - PROVIDER: only available via direct sql updates (for now)"
+    },
+    "fuzzball.api.v3.ApplicationService.ReloadCatalogRepositoryBody": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.ApplicationService.RenderApplicationBody": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.TemplateValues"
+          }
+        },
+        "trackView": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.ApplicationService.UpdateApplicationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/fuzzball.api.v3.SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "keyArt": {
+          "type": "string",
+          "format": "byte"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "categoryIcon": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.ApplicationService.UpdateCatalogRepositoryBody": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ApplicationService.UpsertApplicationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/fuzzball.api.v3.SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string"
+        },
+        "templateSha": {
+          "type": "string"
+        },
+        "supportedValuesSha": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "keyArt": {
+          "type": "string",
+          "format": "byte"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "categoryIcon": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.ApplicationUsageStats": {
+      "type": "object",
+      "properties": {
+        "applicationId": {
+          "type": "string"
+        },
+        "viewCount": {
+          "type": "string",
+          "format": "int64"
+        },
+        "runCount": {
+          "type": "string",
+          "format": "int64"
+        },
+        "editedCount": {
+          "type": "string",
+          "format": "int64"
+        },
+        "copyCount": {
+          "type": "string",
+          "format": "int64"
+        },
+        "uniqueUsers": {
+          "type": "string",
+          "format": "int64"
+        },
+        "lastUsedTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.Artifact": {
+      "type": "object",
+      "properties": {
+        "fileName": {
+          "type": "string"
+        },
+        "payload": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.CatalogRepository": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.CatalogRepositorySummary": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "lastSyncedSha": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.CentralConfig": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.CentralConfigRevision": {
+      "type": "object",
+      "properties": {
+        "revision": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "createdTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.ChangeUserPasswordRequest": {
+      "type": "object",
+      "properties": {
+        "currentPassword": {
+          "type": "string"
+        },
+        "newPassword": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ChangeUserPasswordResponse": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.Cluster": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ClusterKind"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.ClusterStatus"
+        },
+        "apiEndpoint": {
+          "type": "string"
+        },
+        "openapiEndpoint": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ClusterIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ClusterKind": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_KIND_UNSPECIFIED",
+        "CLUSTER_KIND_ORCHESTRATE",
+        "CLUSTER_KIND_FEDERATE"
+      ],
+      "default": "CLUSTER_KIND_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.ClusterRegistrationConfiguration": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ClusterKind"
+        },
+        "apiToken": {
+          "type": "string"
+        },
+        "jwkPublicKey": {
+          "type": "string"
+        },
+        "apiEndpoint": {
+          "type": "string"
+        },
+        "openapiEndpoint": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ClusterStatus": {
+      "type": "string",
+      "enum": [
+        "CLUSTER_STATUS_UNSPECIFIED",
+        "CLUSTER_STATUS_UNSYNCED",
+        "CLUSTER_STATUS_SYNCING",
+        "CLUSTER_STATUS_READY",
+        "CLUSTER_STATUS_UNREACHABLE",
+        "CLUSTER_STATUS_ERROR",
+        "CLUSTER_STATUS_DISABLED"
+      ],
+      "default": "CLUSTER_STATUS_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.CopyApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        }
+      }
+    },
+    "fuzzball.api.v3.CreateAccountRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.CreateApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        },
+        "template": {
+          "type": "string",
+          "format": "byte"
+        },
+        "supportedValues": {
+          "$ref": "#/definitions/fuzzball.api.v3.SupportedTemplateValues"
+        },
+        "category": {
+          "type": "string",
+          "title": "if not provided a default will be set"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "keyArt": {
+          "type": "string",
+          "format": "byte"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "categoryIcon": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.CreateDefaultResourceDefinitionRequest": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.CreateDefaultResourceDefinitionResponse": {
+      "type": "object",
+      "properties": {
+        "definitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.ProvisionerDefinition"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.CreateDefaultStorageRequest": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.CreateDefaultStorageResponse": {
+      "type": "object",
+      "properties": {
+        "storageClassIds": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.StorageClassIDResponse"
+          }
+        },
+        "storageDriverIds": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.DriverIDResponse"
+          }
+        },
+        "secretIds": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.SecretIDResponse"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.CreateSecretRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/fuzzball.api.v3.SecretScope"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        },
+        "value": {
+          "$ref": "#/definitions/fuzzball.api.v3.ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/fuzzball.api.v3.S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/fuzzball.api.v3.HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/fuzzball.api.v3.MapSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageDecryptionSecret"
+        }
+      }
+    },
+    "fuzzball.api.v3.CreateStorageClassRequest": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition"
+        }
+      }
+    },
+    "fuzzball.api.v3.CreateVolumeRequest": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/fuzzball.api.v3.VolumeDefinition"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.DescribeStorageClassResponse": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassInfoResponse"
+        },
+        "pendingExecution": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.DeviceTypeSummary": {
+      "type": "object",
+      "properties": {
+        "deviceType": {
+          "type": "string"
+        },
+        "totalCount": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "availableCount": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "requestedCount": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "fuzzball.api.v3.DriverDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.DriverDefinition.Image"
+        },
+        "cmd": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "envs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "mounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.DriverDefinition.Mount"
+          }
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.DriverDefinition.File"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.DriverDefinition.File": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string",
+          "format": "byte"
+        },
+        "secret": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.DriverDefinition.Image": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.DriverDefinition.Mount": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.DriverError": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "logs": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.DriverIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.DriverInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "driver": {
+          "$ref": "#/definitions/fuzzball.api.v3.DriverDefinition"
+        },
+        "driverError": {
+          "$ref": "#/definitions/fuzzball.api.v3.DriverError"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.Exclusivity": {
+      "type": "string",
+      "enum": [
+        "EXCLUSIVITY_NONE",
+        "EXCLUSIVITY_JOB",
+        "EXCLUSIVITY_WORKFLOW"
+      ],
+      "default": "EXCLUSIVITY_NONE"
+    },
+    "fuzzball.api.v3.GenerateClusterRegistrationConfigurationResponse": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/fuzzball.api.v3.ClusterRegistrationConfiguration"
+        }
+      }
+    },
+    "fuzzball.api.v3.GenerateWorkflowClientMessage": {
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.GenerateWorkflowServerMessage": {
+      "type": "object",
+      "properties": {
+        "workflowYaml": {
+          "type": "string"
+        },
+        "response": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.GetAccountOwnerWorkflowsSummaryDetailsResponse": {
+      "type": "object",
+      "properties": {
+        "accountOwnerWorkflowsSummaryDetails": {
+          "$ref": "#/definitions/fuzzball.api.v3.AccountOwnerWorkflowsSummaryDetails"
+        }
+      },
+      "description": "GetAccountOwnerWorkflowsSummaryDetailsResponse returns workflow details for group owners.\nNOTE: \"Account owner\" refers to group owners (deprecated terminology)."
+    },
+    "fuzzball.api.v3.GetAccountOwnerWorkflowsUsersResponse": {
+      "type": "object",
+      "properties": {
+        "workflowEmails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "GetAccountOwnerWorkflowsUsersResponse returns workflow users for group owners.\nNOTE: \"Account owner\" refers to group owners (deprecated terminology)."
+    },
+    "fuzzball.api.v3.GetApplicationBundleResponse": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        },
+        "values": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.GetApplicationUsageStatsResponse": {
+      "type": "object",
+      "properties": {
+        "stats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.ApplicationUsageStats"
+          }
+        },
+        "nextPageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.GetNodeInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "hostName": {
+          "type": "string"
+        },
+        "cpu": {
+          "type": "string"
+        },
+        "memoryGb": {
+          "type": "number",
+          "format": "float"
+        },
+        "runningJobs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.RunningJob"
+          }
+        },
+        "resourceSummary": {
+          "$ref": "#/definitions/fuzzball.api.v3.ResourceSummary"
+        },
+        "definitionId": {
+          "type": "string"
+        },
+        "resource": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.ResourceShowResponse"
+        }
+      }
+    },
+    "fuzzball.api.v3.GetStageEventsResponse": {
+      "type": "object",
+      "properties": {
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.StageEvent"
+          }
+        },
+        "cursor": {
+          "type": "string"
+        }
+      },
+      "description": "GetStageEventsResponse is the response for the GetStageEvents RPC."
+    },
+    "fuzzball.api.v3.GetWorkflowStatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowPlan"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "workflowStatus": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.GetWorkflowsSummaryResponse": {
+      "type": "object",
+      "properties": {
+        "userWorkflows": {
+          "$ref": "#/definitions/fuzzball.api.v3.SummarizedWorkflowResponse"
+        },
+        "otherOwnerWorkflows": {
+          "$ref": "#/definitions/fuzzball.api.v3.SummarizedWorkflowResponse"
+        },
+        "accountOwnerWorkflowsSummary": {
+          "$ref": "#/definitions/fuzzball.api.v3.AccountOwnerWorkflowsSummary"
+        }
+      }
+    },
+    "fuzzball.api.v3.HTTPSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.HTTPSecretInfo": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ImageDecryptionSecret": {
+      "type": "object",
+      "properties": {
+        "passphrase": {
+          "type": "string"
+        },
+        "pem": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ImageSecret": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ImageSecretInfo": {
+      "type": "object",
+      "properties": {
+        "trustedDomains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ImportCatalogRepositoryRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "ownerKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.ApplicationOwnerKind"
+        }
+      }
+    },
+    "fuzzball.api.v3.ImportCatalogRepositoryResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.InstallDriverRequest": {
+      "type": "object",
+      "properties": {
+        "driver": {
+          "$ref": "#/definitions/fuzzball.api.v3.DriverDefinition"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListAccountsResponse": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.Account"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListApplicationCategoriesResponse": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.ApplicationCategory"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.ListApplicationsResponse": {
+      "type": "object",
+      "properties": {
+        "applications": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.ApplicationMetadata"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListCatalogRepositoriesResponse": {
+      "type": "object",
+      "properties": {
+        "repositories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.CatalogRepositorySummary"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.ListCentralConfigRevisions": {
+      "type": "object",
+      "properties": {
+        "revisions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.CentralConfigRevision"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.ListClustersResponse": {
+      "type": "object",
+      "properties": {
+        "clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.Cluster"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListDriversResponse": {
+      "type": "object",
+      "properties": {
+        "drivers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.DriverInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListNodeInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "hostName": {
+          "type": "string"
+        },
+        "cpu": {
+          "type": "string"
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "memoryGb": {
+          "type": "number",
+          "format": "float"
+        },
+        "devices": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "runningJobs": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "definitionId": {
+          "type": "string"
+        },
+        "resource": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.ResourceShowResponse"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListNodesResponse": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.ListNodeInfo"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.ListProvisionerDefinitionsResponse": {
+      "type": "object",
+      "properties": {
+        "definitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.ProvisionerDefinition"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListSecretsResponse": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.Secret"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListStorageClassesResponse": {
+      "type": "object",
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.StorageClassInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListVolumesResponse": {
+      "type": "object",
+      "properties": {
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.VolumeInfoResponse"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListWorkflowsResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.Workflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.ListWorkflowsScope": {
+      "type": "string",
+      "enum": [
+        "SCOPE_UNSPECIFIED",
+        "SCOPE_USER",
+        "SCOPE_ACCOUNT",
+        "SCOPE_GROUP"
+      ],
+      "default": "SCOPE_UNSPECIFIED",
+      "title": "- SCOPE_USER: SCOPE_USER returns workflows for the user within the currently selected group\n - SCOPE_ACCOUNT: SCOPE_ACCOUNT returns workflows for the group (deprecated, prefer SCOPE_GROUP)\n - SCOPE_GROUP: SCOPE_GROUP returns workflows for the entire group"
+    },
+    "fuzzball.api.v3.LocalLoginRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.LocalLoginResponse": {
+      "type": "object",
+      "properties": {
+        "jwt": {
+          "type": "string"
+        },
+        "organizationId": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.LocalLoginStatusResponse": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "validToken": {
+          "type": "boolean"
+        },
+        "organizationId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.LogEntry": {
+      "type": "object",
+      "properties": {
+        "podName": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "level": {
+          "$ref": "#/definitions/fuzzball.api.v3.LogLevel"
+        }
+      }
+    },
+    "fuzzball.api.v3.LogLevel": {
+      "type": "string",
+      "enum": [
+        "LOG_LEVEL_UNSPECIFIED",
+        "LOG_LEVEL_DEBUG",
+        "LOG_LEVEL_INFO",
+        "LOG_LEVEL_WARN",
+        "LOG_LEVEL_ERROR",
+        "LOG_LEVEL_FATAL"
+      ],
+      "default": "LOG_LEVEL_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.MapSecret": {
+      "type": "object",
+      "properties": {
+        "map": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.OptionsInput": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "list of options for the input"
+        }
+      }
+    },
+    "fuzzball.api.v3.Organization": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.OrganizationRelationship": {
+      "type": "string",
+      "enum": [
+        "ORGANIZATION_MEMBER",
+        "ORGANIZATION_OWNER"
+      ],
+      "default": "ORGANIZATION_MEMBER"
+    },
+    "fuzzball.api.v3.OrganizationService.ResetOrganizationMemberPasswordBody": {
+      "type": "object",
+      "properties": {
+        "newPassword": {
+          "type": "string",
+          "title": "empty = auto-generate on backend"
+        },
+        "requireUpdatePassword": {
+          "type": "boolean",
+          "description": "When true, the password is set as temporary and the user is required to change it on next login.\nWhen false (default), the password is permanent and no forced change is required."
+        }
+      }
+    },
+    "fuzzball.api.v3.ProvisionerDefinition": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "backendId": {
+          "type": "string"
+        },
+        "resource": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.ResourceShowResponse"
+        },
+        "costPerHourEstimate": {
+          "type": "number",
+          "format": "double"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "exclusive": {
+          "$ref": "#/definitions/fuzzball.api.v3.Exclusivity"
+        },
+        "ttlBuffer": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "fuzzball.api.v3.RegisterClusterRequest": {
+      "type": "object",
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/fuzzball.api.v3.ClusterRegistrationConfiguration"
+        }
+      }
+    },
+    "fuzzball.api.v3.RegisterClusterResponse": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.ReloadCatalogRepositoryResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "updated": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.RenderApplicationTemplateRequest": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.TemplateValues"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.RenderApplicationTemplateResponse": {
+      "type": "object",
+      "properties": {
+        "renderedWorkflow": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.RequestedDevice": {
+      "type": "object",
+      "properties": {
+        "deviceType": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "fuzzball.api.v3.ResetOrganizationMemberPasswordResponse": {
+      "type": "object",
+      "properties": {
+        "generatedPassword": {
+          "type": "string",
+          "title": "Only populated when password was auto-generated"
+        }
+      }
+    },
+    "fuzzball.api.v3.ResourceSummary": {
+      "type": "object",
+      "properties": {
+        "totalCores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "availableCores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "allocatedCores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalMemoryGb": {
+          "type": "number",
+          "format": "float"
+        },
+        "availableMemoryGb": {
+          "type": "number",
+          "format": "float"
+        },
+        "allocatedMemoryGb": {
+          "type": "number",
+          "format": "float"
+        },
+        "deviceSummaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.DeviceTypeSummary"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.RunningJob": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string"
+        },
+        "jobName": {
+          "type": "string"
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "requestedCores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "requestedMemoryGb": {
+          "type": "number",
+          "format": "float"
+        },
+        "requestedDeviceDetails": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.RequestedDevice"
+          }
+        },
+        "startedTimestamp": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "fuzzball.api.v3.S3Secret": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string"
+        },
+        "secretAccessKey": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "sessionToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.S3SecretInfo": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        }
+      },
+      "title": "Non-sensitive information about secrets"
+    },
+    "fuzzball.api.v3.ScheduleCatalogSyncRequest": {
+      "type": "object",
+      "properties": {
+        "cron": {
+          "type": "string"
+        },
+        "suspend": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.ScoreWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition"
+        },
+        "withChecks": {
+          "type": "boolean"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        }
+      }
+    },
+    "fuzzball.api.v3.ScoreWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "score": {
+          "type": "number",
+          "format": "float"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "costEstimate": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "fuzzball.api.v3.Secret": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "$ref": "#/definitions/fuzzball.api.v3.SecretScope"
+        },
+        "type": {
+          "$ref": "#/definitions/fuzzball.api.v3.SecretType"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean",
+          "title": "used for organization scoped secrets"
+        },
+        "s3": {
+          "$ref": "#/definitions/fuzzball.api.v3.S3SecretInfo"
+        },
+        "http": {
+          "$ref": "#/definitions/fuzzball.api.v3.HTTPSecretInfo"
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageSecretInfo"
+        }
+      }
+    },
+    "fuzzball.api.v3.SecretIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.SecretScope": {
+      "type": "string",
+      "enum": [
+        "SECRET_SCOPE_UNSPECIFIED",
+        "SECRET_SCOPE_USER",
+        "SECRET_SCOPE_ACCOUNT",
+        "SECRET_SCOPE_ORGANIZATION",
+        "SECRET_SCOPE_CLUSTER",
+        "SECRET_SCOPE_GROUP"
+      ],
+      "default": "SECRET_SCOPE_UNSPECIFIED",
+      "description": " - SECRET_SCOPE_ACCOUNT: Deprecated: Use SECRET_SCOPE_GROUP instead.\n - SECRET_SCOPE_GROUP: SECRET_SCOPE_GROUP is the preferred name for group-scoped secrets (formerly SECRET_SCOPE_ACCOUNT)."
+    },
+    "fuzzball.api.v3.SecretService.UpdateOrganizationSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/fuzzball.api.v3.ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/fuzzball.api.v3.S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/fuzzball.api.v3.HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/fuzzball.api.v3.MapSecret"
+        }
+      }
+    },
+    "fuzzball.api.v3.SecretService.UpdateSecretBody": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/fuzzball.api.v3.ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/fuzzball.api.v3.S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/fuzzball.api.v3.HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageSecret"
+        },
+        "map": {
+          "$ref": "#/definitions/fuzzball.api.v3.MapSecret"
+        }
+      }
+    },
+    "fuzzball.api.v3.SecretTemplateValue": {
+      "type": "object",
+      "properties": {
+        "reference": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/fuzzball.api.v3.SecretType"
+        }
+      }
+    },
+    "fuzzball.api.v3.SecretType": {
+      "type": "string",
+      "enum": [
+        "SECRET_TYPE_UNSPECIFIED",
+        "SECRET_TYPE_VALUE",
+        "SECRET_TYPE_S3",
+        "SECRET_TYPE_HTTP",
+        "SECRET_TYPE_IMAGE",
+        "SECRET_TYPE_MAP",
+        "SECRET_TYPE_DECRYPTION_SIF",
+        "UNSPECIFIED",
+        "VALUE",
+        "S3",
+        "HTTP",
+        "IMAGE",
+        "MAP",
+        "DECRYPTION_SIF"
+      ],
+      "default": "SECRET_TYPE_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.SelectAccountResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.SetVolumeStatusResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.VolumeStatus"
+        }
+      }
+    },
+    "fuzzball.api.v3.StageEvent": {
+      "type": "object",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "eventType": {
+          "$ref": "#/definitions/fuzzball.api.v3.StageEventType"
+        },
+        "stageKind": {
+          "$ref": "#/definitions/fuzzball.api.v3.StageKind"
+        },
+        "stageName": {
+          "type": "string"
+        },
+        "stageId": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "description": "StageEvent represents a single event in the lifecycle of a workflow stage."
+    },
+    "fuzzball.api.v3.StageEventType": {
+      "type": "string",
+      "enum": [
+        "STAGE_EVENT_TYPE_UNSPECIFIED",
+        "STAGE_EVENT_TYPE_STAGE_STARTED",
+        "STAGE_EVENT_TYPE_STAGE_FINISHED",
+        "STAGE_EVENT_TYPE_STAGE_FAILED",
+        "STAGE_EVENT_TYPE_STAGE_CANCELED",
+        "STAGE_EVENT_TYPE_STAGE_READY",
+        "STAGE_EVENT_TYPE_WORKFLOW_STARTED",
+        "STAGE_EVENT_TYPE_WORKFLOW_FINISHED",
+        "STAGE_EVENT_TYPE_WORKFLOW_FAILED",
+        "STAGE_EVENT_TYPE_WORKFLOW_CANCELED",
+        "STAGE_EVENT_TYPE_IMAGE_PULL_STARTED",
+        "STAGE_EVENT_TYPE_IMAGE_PULL_COMPLETED",
+        "STAGE_EVENT_TYPE_IMAGE_CACHE_HIT",
+        "STAGE_EVENT_TYPE_IMAGE_CONVERT_STARTED",
+        "STAGE_EVENT_TYPE_IMAGE_CONVERT_COMPLETED",
+        "STAGE_EVENT_TYPE_CONTAINER_STARTED",
+        "STAGE_EVENT_TYPE_CONTAINER_EXITED",
+        "STAGE_EVENT_TYPE_HEALTH_CHECK_FAILED",
+        "STAGE_EVENT_TYPE_READINESS_PROBE_PASSED",
+        "STAGE_EVENT_TYPE_READINESS_PROBE_FAILED",
+        "STAGE_EVENT_TYPE_WAITING_ON_DEPENDENCY",
+        "STAGE_EVENT_TYPE_DEPENDENCY_SATISFIED",
+        "STAGE_EVENT_TYPE_DEPENDENCY_FAILED",
+        "STAGE_EVENT_TYPE_RESOURCES_ALLOCATED",
+        "STAGE_EVENT_TYPE_PROVISIONING_REQUESTED",
+        "STAGE_EVENT_TYPE_PROVISIONING_COMPLETED",
+        "STAGE_EVENT_TYPE_PROVISIONING_BACKEND",
+        "STAGE_EVENT_TYPE_INSTANCE_LAUNCHED",
+        "STAGE_EVENT_TYPE_INSTANCE_READY",
+        "STAGE_EVENT_TYPE_INSTANCE_FAILED",
+        "STAGE_EVENT_TYPE_VOLUME_CREATE_STARTED",
+        "STAGE_EVENT_TYPE_VOLUME_STORAGE_INFO",
+        "STAGE_EVENT_TYPE_VOLUME_CREATED",
+        "STAGE_EVENT_TYPE_FILE_TRANSFER_STARTED",
+        "STAGE_EVENT_TYPE_FILE_TRANSFER_TYPE",
+        "STAGE_EVENT_TYPE_FILE_TRANSFER_COMPLETED",
+        "STAGE_EVENT_TYPE_ERROR"
+      ],
+      "default": "STAGE_EVENT_TYPE_UNSPECIFIED",
+      "description": "StageEventType enumerates the types of events that can occur during stage execution.\n\n - STAGE_EVENT_TYPE_STAGE_STARTED: Stage lifecycle\n - STAGE_EVENT_TYPE_WORKFLOW_STARTED: Workflow lifecycle\n - STAGE_EVENT_TYPE_IMAGE_PULL_STARTED: Image pull events\n - STAGE_EVENT_TYPE_CONTAINER_STARTED: Container events\n - STAGE_EVENT_TYPE_WAITING_ON_DEPENDENCY: Dependencies\n - STAGE_EVENT_TYPE_RESOURCES_ALLOCATED: Resource allocation\n - STAGE_EVENT_TYPE_PROVISIONING_REQUESTED: Provisioning events\n - STAGE_EVENT_TYPE_VOLUME_CREATE_STARTED: Volume events\n - STAGE_EVENT_TYPE_FILE_TRANSFER_STARTED: File transfer events\n - STAGE_EVENT_TYPE_ERROR: Error"
+    },
+    "fuzzball.api.v3.StageKind": {
+      "type": "string",
+      "enum": [
+        "STAGE_KIND_UNSPECIFIED",
+        "STAGE_KIND_WORKFLOW",
+        "STAGE_KIND_JOB",
+        "STAGE_KIND_FILE",
+        "STAGE_KIND_IMAGE",
+        "STAGE_KIND_VOLUME",
+        "STAGE_KIND_COMPLETED",
+        "STAGE_KIND_SERVICE"
+      ],
+      "default": "STAGE_KIND_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.StartApplicationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "title": "name to assign the workflow"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.TemplateValues"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.StartWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "definition": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition"
+        },
+        "workflowId": {
+          "type": "string"
+        },
+        "secretsMap": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowSecretsMap"
+        },
+        "clusterId": {
+          "type": "string",
+          "title": "optional cluster ID when submitting jobs from a federate cluster"
+        },
+        "rawSpecification": {
+          "type": "string"
+        },
+        "applicationId": {
+          "type": "string",
+          "title": "optional application ID to track application usage stats"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "mount": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Mount"
+        },
+        "access": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Access"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "secrets": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Secrets"
+        },
+        "properties": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Properties"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Capability"
+          }
+        },
+        "scope": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Scope"
+        },
+        "capacity": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Capacity"
+        },
+        "affinities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Affinity"
+          }
+        },
+        "volumes": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Volumes"
+        },
+        "restricted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Access": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Access.Type"
+        },
+        "mode": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Access.Mode"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Access.Mode": {
+      "type": "string",
+      "enum": [
+        "MODE_UNSPECIFIED",
+        "SINGLE_NODE_WRITER",
+        "SINGLE_NODE_READER_ONLY",
+        "MULTI_NODE_READER_ONLY",
+        "MULTI_NODE_SINGLE_WRITER",
+        "MULTI_NODE_MULTI_WRITER",
+        "SINGLE_NODE_SINGLE_WRITER",
+        "SINGLE_NODE_MULTI_WRITER"
+      ],
+      "default": "MODE_UNSPECIFIED",
+      "title": "- MODE_UNSPECIFIED: SINGLE_NODE_XXX are not supported yet\n - MULTI_NODE_SINGLE_WRITER: not supported yet"
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Access.Type": {
+      "type": "string",
+      "enum": [
+        "TYPE_UNSPECIFIED",
+        "FILESYSTEM",
+        "BLOCK"
+      ],
+      "default": "TYPE_UNSPECIFIED",
+      "title": "- BLOCK: BLOCK is not supported yet"
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Affinity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Affinity.Type"
+        },
+        "key": {
+          "type": "string"
+        },
+        "filter": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Affinity.Type": {
+      "type": "string",
+      "enum": [
+        "AFFINITY_UNSPECIFIED",
+        "ANNOTATION",
+        "RESOURCE"
+      ],
+      "default": "AFFINITY_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Capability": {
+      "type": "string",
+      "enum": [
+        "CAPABILITY_UNSPECIFIED",
+        "SELINUX"
+      ],
+      "default": "CAPABILITY_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Capacity": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "unit": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Capacity.Unit"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Capacity.Unit": {
+      "type": "string",
+      "enum": [
+        "UNIT_UNSPECIFIED",
+        "MIB",
+        "GIB",
+        "TIB",
+        "PIB",
+        "EIB"
+      ],
+      "default": "UNIT_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Mount": {
+      "type": "object",
+      "properties": {
+        "filesystem": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Mount.Ownership"
+        },
+        "group": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Mount.Ownership"
+        },
+        "permissions": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Mount.Ownership": {
+      "type": "string",
+      "enum": [
+        "OWNERSHIP_UNSPECIFIED",
+        "ROOT",
+        "USER",
+        "ACCOUNT",
+        "GROUP"
+      ],
+      "default": "OWNERSHIP_UNSPECIFIED",
+      "title": "- ACCOUNT: ACCOUNT is supported with group ownership (deprecated, prefer GROUP)\n - GROUP: GROUP ownership allows all group members to access the volume"
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Properties": {
+      "type": "object",
+      "properties": {
+        "retainOnDelete": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Scope": {
+      "type": "string",
+      "enum": [
+        "SCOPE_UNSPECIFIED",
+        "ALL",
+        "USER",
+        "ACCOUNT",
+        "GROUP"
+      ],
+      "default": "SCOPE_UNSPECIFIED",
+      "title": "- ACCOUNT: ACCOUNT scope limits visibility to group members (deprecated, prefer GROUP)\n - GROUP: GROUP scope limits visibility to group members"
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Secrets": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Volumes": {
+      "type": "object",
+      "properties": {
+        "nameArgs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Volumes.NameArg"
+          }
+        },
+        "nameFormat": {
+          "type": "string"
+        },
+        "maxByAccount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "max_by_account limits the maximum number of volumes per group.\nNote: Field name uses legacy \"account\" terminology but represents group limits.\nKept for API compatibility with existing clients."
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassDefinition.Volumes.NameArg": {
+      "type": "string",
+      "enum": [
+        "NAME_ARG_UNSPECIFIED",
+        "USERNAME",
+        "ORGANIZATION_ID",
+        "ACCOUNT_ID",
+        "GROUP_ID",
+        "WORKFLOW_ID",
+        "CUSTOM_NAME"
+      ],
+      "default": "NAME_ARG_UNSPECIFIED",
+      "title": "- ACCOUNT_ID: ACCOUNT_ID for volume naming (deprecated, prefer GROUP_ID)\n - GROUP_ID: GROUP_ID for volume naming"
+    },
+    "fuzzball.api.v3.StorageClassIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "driverId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "class": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition"
+        },
+        "scope": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassDefinition.Scope"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.StorageClassStatus"
+        },
+        "restricted": {
+          "type": "boolean"
+        },
+        "persistent": {
+          "type": "boolean"
+        },
+        "retain": {
+          "type": "boolean"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageClassStatus": {
+      "type": "string",
+      "enum": [
+        "STORAGE_CLASS_STATUS_UNSPECIFIED",
+        "STORAGE_CLASS_STATUS_NOT_READY",
+        "STORAGE_CLASS_STATUS_READY",
+        "STORAGE_CLASS_STATUS_DISABLED",
+        "STORAGE_CLASS_STATUS_ERROR"
+      ],
+      "default": "STORAGE_CLASS_STATUS_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.StorageVolumeService.SetVolumeStatusBody": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.VolumeStatus"
+        }
+      }
+    },
+    "fuzzball.api.v3.StorageVolumeService.UpdateVolumeBody": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/fuzzball.api.v3.VolumeDefinition"
+        }
+      }
+    },
+    "fuzzball.api.v3.SummarizedWorkflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "runningStages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowStage"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.SummarizedWorkflowResponse": {
+      "type": "object",
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.SummarizedWorkflow"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.SupportedTemplateValues": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.TemplateValues"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.TemplateValues": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "stringValue": {
+          "type": "string"
+        },
+        "uintValue": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "boolValue": {
+          "type": "boolean"
+        },
+        "secretValue": {
+          "$ref": "#/definitions/fuzzball.api.v3.SecretTemplateValue"
+        },
+        "volumeValue": {
+          "$ref": "#/definitions/fuzzball.api.v3.VolumeTemplateValue"
+        },
+        "displayCategory": {
+          "type": "string",
+          "title": "optional, used for UI grouping"
+        },
+        "optionsInput": {
+          "$ref": "#/definitions/fuzzball.api.v3.OptionsInput",
+          "title": "optional, used for enum input"
+        }
+      }
+    },
+    "fuzzball.api.v3.TerminalSize": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "cols": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "x": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "y": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "fuzzball.api.v3.UpdateOrganizationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.UpdateUserAccountResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.UpdateUserProfileAvatarRequest": {
+      "type": "object",
+      "properties": {
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.UpdateUserProfileRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.UpdateUserProfileSettingsRequest": {
+      "type": "object",
+      "properties": {
+        "settings": {
+          "type": "object"
+        }
+      },
+      "description": "TODO: given this is more of a backend support item we may want to remove this from the public api."
+    },
+    "fuzzball.api.v3.UsageStatsScope": {
+      "type": "string",
+      "enum": [
+        "USAGE_STATS_SCOPE_UNSPECIFIED",
+        "USAGE_STATS_SCOPE_ALL",
+        "USAGE_STATS_SCOPE_ACCOUNT",
+        "USAGE_STATS_SCOPE_ORGANIZATION"
+      ],
+      "default": "USAGE_STATS_SCOPE_UNSPECIFIED",
+      "title": "- USAGE_STATS_SCOPE_ALL: Usage across all accounts/organizations\n - USAGE_STATS_SCOPE_ACCOUNT: Usage within the user's account\n - USAGE_STATS_SCOPE_ORGANIZATION: Usage within the user's organization"
+    },
+    "fuzzball.api.v3.User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "fuzzball.api.v3.UserListResponse": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.User"
+          }
+        },
+        "pageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.UserProfile": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "organizationId": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string",
+          "format": "byte"
+        },
+        "settings": {
+          "type": "object"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "clusterAdmin": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.ValidateWorkflowRequest": {
+      "type": "object",
+      "properties": {
+        "definition": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition"
+        }
+      }
+    },
+    "fuzzball.api.v3.ValidateWorkflowResponse": {
+      "type": "object"
+    },
+    "fuzzball.api.v3.ValueSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.VersionGetResponse": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.VolumeDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.VolumeIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.VolumeInfoResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "accessTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.VolumeStatus"
+        },
+        "clusterId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.VolumeStatus": {
+      "type": "string",
+      "enum": [
+        "VOLUME_STATUS_UNSPECIFIED",
+        "VOLUME_STATUS_ENABLED",
+        "VOLUME_STATUS_DISABLED"
+      ],
+      "default": "VOLUME_STATUS_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.VolumeTemplateValue": {
+      "type": "object",
+      "properties": {
+        "reference": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.Workflow": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "error": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "specification": {
+          "type": "string",
+          "format": "byte"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowStatus"
+        },
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "clusterId": {
+          "type": "string"
+        },
+        "rawSpecification": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string",
+          "title": "account_id is the group ID this workflow belongs to (deprecated naming, represents a group)"
+        },
+        "jobs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowStage"
+          }
+        },
+        "totalJobs": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowDefinition": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "version defines the version of the workflow document."
+        },
+        "volumes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Volume"
+          },
+          "description": "volumes is a map defining volumes to use for this workflow by name.\nMap keys define the name of the volume and values are specifications\ndetailing the data volume. Volume names are used by different\ncomponents of the workflow to reference a particular volume instance."
+        },
+        "jobs": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job"
+          },
+          "description": "jobs is a map defining jobs to run as a part of the workflow.\nMap keys define the name of the job and values are specifications\ndetailing the compute job. Job names are used by different components\nof the workflow to reference a particular compute job instance."
+        },
+        "completed": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Completed",
+          "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Annotations for the whole workflow. Currently, this is used by the\nscheduler to place jobs in a certain topology zone"
+        },
+        "defaults": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Defaults"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "files is a map defining files that may be injected into volumes and jobs.\nMap keys define the name of the file and values are the file's contents.\nFiles names are used by job and volume.ingress components\nto reference a specific file."
+        },
+        "services": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Service"
+          }
+        }
+      },
+      "description": "WorkflowDefinition is the highest level unit of work for a Fuzzball cluster.\nWorkflows consist of orchestrating data volumes, container images and\ncontainer execution across a compute cluster."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Completed": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      },
+      "description": "TODO: Remove from public API as this is just an anchor for DAG execution."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Defaults": {
+      "type": "object",
+      "properties": {
+        "job": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Defaults.Job"
+        }
+      },
+      "description": "Default defines the default settings that should be applied to all jobs in the workflow.\nThese can be overridden at the job level."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Defaults.Job": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside all job\ncontainers.  Will be overridden by job level env variables."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "policy": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Defaults.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Used internally to store the job name.  If this field is present in a\ndefinition then it will be ignored in preference for the map key used in\nthe `jobs` field."
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.URI",
+          "title": "Image is the URI to the container image to be used for this job.\nSupported uri formats are: \"docker://...\" and \"oras://\" for OCI\nand SIF(Singularity Image Format) images respectively.\nE.g. docker://alpine:latest"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "command is the arguments executed by the container process."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside of the job\ncontainer."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "cwd allows the specification of the the working dirctory used by the job.\nThis must be an absolute path. If unset the working directory defaults\nfirst to the working directory in the OCI image config if present and\nthen to \"/\"."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "requires is a list of prerequisite jobs/services in the workflow that must be\ncompleted before this job may be started. This allows jobs within a\nworkflow to be formed into a directed acyclic graph. If requirements\nspecified by different jobs results in a cycle, the workflow will fail to\nstart.\n\nDeprecated: use the `dependsOn` field instead.\nIgnored if `dependsOn` is set.\nIf used instead of `dependsOn`, dependencies are assumed to be \"when jobN has finished\"."
+        },
+        "policy": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a job such as max execution time and retries on failure."
+        },
+        "resource": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        },
+        "multinode": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Multinode",
+          "description": "multinode enables a job to run across multiple nodes in parallel."
+        },
+        "task-array": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.TaskArray",
+          "description": "task_array enables a job to be broken up into multiple tasks that run\nconcurrently. This is useful for doing embarrassingly parallel compute\nwork."
+        },
+        "network": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Network",
+          "title": "network defines if the job should run inside its own netowrk namespace"
+        },
+        "script": {
+          "type": "string",
+          "title": "shellbang script executed via command"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "args passed to above script field, can also be passed to existing command"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "depends-on": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Dependency"
+          },
+          "description": "dependsOn is a list of concrete dependencies that must be satisfied before this job can run."
+        }
+      },
+      "description": "Job is a single compute \"step\" in a workflow.\nThere are a variety of different types of jobs that\nresult in one or more containers being spawned.\nBy default, a single container is spawned unless the\nTaskArray or Multinode fields are specified."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.Dependency": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name is the name of the job to depend on."
+        },
+        "status": {
+          "type": "string",
+          "title": "status is the status that this dependency must be in before this job can run.\nValid values (case-insensitive): RUNNING (Services Only), FINISHED"
+        },
+        "description": {
+          "type": "string",
+          "description": "description is a human readable description of the dependency."
+        }
+      },
+      "description": "Dependency is a concrete dependency that must be satisfied before this job can run."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.Mount": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "location specifies the destination within the container filesystem to\nmount a volume directory. This must be an absolute path."
+        }
+      },
+      "description": "Mount is the specification for how a volume gets mounted into a job\ncontainer."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.Multinode": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "nodes is the number of nodes to run job across in parallel."
+        },
+        "implementation": {
+          "type": "string",
+          "title": "implementation is the specific implementation of multinode to be used.\nThis must match the implementation used by the application within your\njob container because different multinode implementations require\nslightly different wire up configurations. Must be one of: \"ompi\",\n\"openmpi\", \"mpich\", \"gasnet\", \"generic\""
+        },
+        "procsPerNode": {
+          "type": "integer",
+          "format": "int64",
+          "description": "procs_per_node specifies the number of processes to spawn\nwithin each job container. If not specified, this value defaults to\nthe number of CPUs allocated to the job container. The total number\nof processes spawned for a job can be calculated by multiplying\nthis value by the number of nodes requested."
+        }
+      },
+      "description": "Multinode enables a job to run multiple containers across multiple nodes\nin parallel by leveraging various implementation for communication and\nsynchronization."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.Network": {
+      "type": "object",
+      "properties": {
+        "isolated": {
+          "type": "boolean",
+          "description": "isolated forces the use of a container network namespace.\nThis is required for reaching a job container port with port\nforwarding."
+        },
+        "exposeTcp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_tcp is a list of container TCP ports to expose."
+        },
+        "exposeUdp": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "expose_udp is a list of container UDP ports to expose."
+        }
+      },
+      "description": "Network defines if the job should be run inside its own network namespace\nand enabled optional exposure of job container ports.\nThis is required if you want to expose ports from the job container\ndirectly or via port forwarding."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Resource.Cpu",
+          "description": "cpu details CPU resource requirements for the job."
+        },
+        "memory": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Resource.Memory",
+          "description": "memory details memory requirements for the job."
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "device details device resource requirements for the job."
+        },
+        "exclusive": {
+          "type": "boolean",
+          "description": "exclusive sets the requirement that this job is the only one running on\na node."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is a map of string key value pairs that can be used to\nspecify custom behavior implemented by the workflow system to meet\nneeds beyond what the first class resource parameters currently\nprovide. Potential use cases could be along the lines of:matching a job\nto a specfic node pool, requiring a specific CPU microarchitecture or\nGPU family, etc."
+        }
+      },
+      "description": "Resource specifies hardware requirements that must be met for the\nexecution of a job."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.Resource.Cpu": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "string",
+          "description": "affinity dictates how the binding of tasks to the specific hardware\nlayout occurs. Must be one of \"NUMA\", \"SOCKET\", or \"CORE\". An unset\naffinity defaults to \"CORE\"."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64",
+          "description": "cores is the number of processor cores required."
+        },
+        "threads": {
+          "type": "boolean",
+          "description": "threads dictates if hardware threads of allocated cores are exposed\nto the job container."
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64",
+          "description": "sockets is the number of sockets required."
+        }
+      },
+      "description": "CPU contains relevant details about CPU requirements."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.Resource.Memory": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "size is the amount of memory required for the job. If no unit is\nspecified, byte is the default. E.g. 32KiB, 1GB, 32GiB."
+        },
+        "byCore": {
+          "type": "boolean",
+          "description": "by_core defines if the memory is specified per CPU core."
+        }
+      },
+      "description": "Memory contains relevant details about RAM requirements."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Job.TaskArray": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "format": "int64",
+          "description": "start is the start of the range for Task ID values. Inclusive."
+        },
+        "end": {
+          "type": "integer",
+          "format": "int64",
+          "description": "end is the end of the Task ID values. Inclusive."
+        },
+        "concurrency": {
+          "type": "integer",
+          "format": "int64",
+          "description": "concurrency is a limit on the number of tasks that can be run in\nparallel. The max concurrency for a workflow job is 200."
+        }
+      },
+      "description": "TaskArray allows a job to be broken up in an embarrassingly parallel\nmanner for more effective execution. TaskArray jobs are automatically\npopulated with a `FB_TASK_ID` environment variable to indicate the index\nwithin the task array range of the currently executing task to the\napplication."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Policy": {
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Policy.Timeout",
+          "description": "timeout specifies rules related to the duration of a workflow step."
+        },
+        "retry": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Policy.Retry",
+          "description": "Deprecated: retry is not implemented and will be removed in a future\nrelease. This field is accepted but ignored."
+        }
+      },
+      "description": "Policy contains configurable rules for the execution of a workflow step.\nThe default policy for a step will set a value for timeout if a custom one\nis not specified."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Policy.Retry": {
+      "type": "object",
+      "properties": {
+        "attempts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Deprecated: attempts has no effect."
+        }
+      },
+      "description": "Deprecated: Retry is not implemented. This message will be removed in\na future release."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Policy.Timeout": {
+      "type": "object",
+      "properties": {
+        "execute": {
+          "type": "string",
+          "description": "execute  is the maximum allowed duration of a workflow step to run\nbefore it is failed."
+        }
+      },
+      "description": "Timeout specifies rules related to the duration of a workflow step."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Probe": {
+      "type": "object",
+      "properties": {
+        "exec": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Probe.ExecAction",
+          "title": "Probe action (exactly one must be specified)"
+        },
+        "http-get": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Probe.HTTPGetAction"
+        },
+        "tcp-socket": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Probe.TCPSocketAction"
+        },
+        "grpc": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Probe.GRPCAction"
+        },
+        "initial-delay-seconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "K8s: initialDelaySeconds",
+          "title": "Kubernetes-compatible timing fields"
+        },
+        "period-seconds": {
+          "type": "integer",
+          "format": "int32",
+          "title": "K8s: periodSeconds"
+        },
+        "timeout-seconds": {
+          "type": "integer",
+          "format": "int32",
+          "title": "K8s: timeoutSeconds"
+        },
+        "success-threshold": {
+          "type": "integer",
+          "format": "int32",
+          "title": "K8s: successThreshold"
+        },
+        "failure-threshold": {
+          "type": "integer",
+          "format": "int32",
+          "title": "K8s: failureThreshold"
+        }
+      },
+      "title": "Probe defines Kubernetes-compatible health checking configuration"
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Probe.ExecAction": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "ExecAction represents a command-based probe (matches Kubernetes exactly)"
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Probe.GRPCAction": {
+      "type": "object",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "service": {
+          "type": "string",
+          "title": "Optional gRPC service name"
+        }
+      },
+      "title": "GRPCAction represents a gRPC probe (matches Kubernetes exactly)"
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Probe.HTTPGetAction": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "scheme": {
+          "type": "string",
+          "title": "HTTP or HTTPS"
+        },
+        "http-headers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Probe.HTTPHeader"
+          }
+        }
+      },
+      "title": "HTTPGetAction represents an HTTP GET probe (matches Kubernetes exactly)"
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Probe.HTTPHeader": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": "HTTPHeader represents an HTTP header for HTTP probes (matches Kubernetes exactly)"
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Probe.TCPSocketAction": {
+      "type": "object",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "title": "TCPSocketAction represents a TCP socket probe (matches Kubernetes exactly)"
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Service": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Used internally to store the job name.  If this field is present in a\ndefinition then it will be ignored in preference for the map key used in\nthe `jobs` field."
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.URI",
+          "title": "Image is the URI to the container image to be used for this job.\nSupported uri formats are: \"docker://...\" and \"oras://\" for OCI\nand SIF(Singularity Image Format) images respectively.\nE.g. docker://alpine:latest"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "command is the arguments executed by the container process."
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "env is a list of environment variables to be exposed inside of the job\ncontainer."
+        },
+        "mounts": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Mount"
+          },
+          "description": "mounts is a map containing a key that references a volume by name and\nvalue containing a specification with details of how that volume should\nbe mounted into the job container."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "cwd allows the specification of the the working dirctory used by the job.\nThis must be an absolute path. If unset the working directory defaults\nfirst to the working directory in the OCI image config if present and\nthen to \"/\"."
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "requires is a list of prerequisite jobs/services in the workflow that must be\ncompleted before this service may be started. This allows jobs within a\nworkflow to be formed into a directed acyclic graph. If requirements\nspecified by different jobs results in a cycle, the workflow will fail to\nstart.\n\nDeprecated: use the `dependsOn` field instead.\nIgnored if `dependsOn` is set.\nIf used instead of `dependsOn`, dependencies are assumed to be \"when jobN has finished\"."
+        },
+        "resource": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Resource",
+          "description": "resource specifies the hardware requirements that must be met for the job\nto be executed. This is used by the scheduler to determine if and where a\njob can be scheduled to run."
+        },
+        "multinode": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Multinode",
+          "description": "multinode enables a service to run across multiple nodes in parallel."
+        },
+        "network": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Service.Network"
+        },
+        "script": {
+          "type": "string",
+          "title": "shellbang script executed via command"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "args passed to above script field, can also be passed to existing command"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "depends-on": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Job.Dependency"
+          },
+          "description": "dependsOn is a list of concrete dependencies that must be satisfied before this service can run."
+        },
+        "persist": {
+          "type": "boolean",
+          "description": "defines if the service should run even if there are no running or waiting jobs in the workflow.\nIf persist is set to false, the service is stopped when all dependant jobs and services have stopped.\nIf persist is set to true, the service runs even if there are no dependant jobs/services and continues until the workflow is cancelled."
+        },
+        "readiness-probe": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Probe",
+          "title": "readinessProbe controls the STARTED → RUNNING transition of the service (required for proper lifecycle monitoring)"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Service.Network": {
+      "type": "object",
+      "properties": {
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Service.Network.Port"
+          }
+        },
+        "endpoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Service.Network.Endpoint"
+          },
+          "description": "Configures fuzzball endpoints to expose a service's functionality."
+        }
+      },
+      "description": "Network defines if the job should be run inside its own network namespace\nand enabled optional exposure of job container ports.\nThis is required if you want to expose ports from the job container\ndirectly or via port forwarding."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Service.Network.Endpoint": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "port-name": {
+          "type": "string",
+          "description": "The name of the port defined above to proxy to."
+        },
+        "protocol": {
+          "type": "string",
+          "title": "The endpoint's intended protocol.\nValid values are: http, https, grpc, grpcs, tcp, tls"
+        },
+        "type": {
+          "type": "string",
+          "title": "The type of endpoint to create.\nValid values are: subdomain, path\nsubdomain - creates a subdomain endpoint like myservice.workflow_id.account_id.fuzzball\npath - creates a path based endpoint like /endpoints/account_id/workflow_id/myservice"
+        },
+        "scope": {
+          "type": "string",
+          "title": "The scope defines who can access this endpoint.\nValid values are: user, group, organization, public\nuser - only the workflow creator can access\ngroup - anyone in the same account can access\norganization - anyone in the same organization can access\npublic - no authentication required\nDefault: group (if not specified)"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Service.Network.Port": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name used to refer to this port."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The port number exposed by the service container."
+        },
+        "protocol": {
+          "type": "string",
+          "title": "The protocol used by this port. Valid values are: tcp, udp"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowDefinition.URI": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "uri is the uri of the resource to be accessed."
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "secrets is a map of key value pairs to use to access resource.\nThe key specifies the type of data that is being used and the value\nspecifies raw data or a template for the workflow system to populate with\ndata internally from the secrets engine."
+        },
+        "secret": {
+          "type": "string"
+        },
+        "decryptionSecret": {
+          "type": "string"
+        }
+      },
+      "description": "URI contains the specification for a resource to access as well as\nadditional data necessary for access such as credentials."
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Volume": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the key value of the volume in the volume map containing this\nstruct. This is normally set internally by client side code when parsing\nworkflow DSLs, but will need to be set when calling the API directly."
+        },
+        "type": {
+          "type": "string",
+          "title": "type is the kind of volume. This currently determines the lifetime of the\nvolume and the data contained within it.\nEphemeral volumes are empty upon creation and have a lifespan of the\nworkflow duration. Upon workflow completion the volume and its data are\ndeleted. Host volumes represent directories on the shared filesystems of\nthe nodes themselves. They must be pre-existing and fall under\ndirectories specified in the shared-fs-roots config property of the\nVolume service. Must be one of \"EPHEMERAL\" or \"HOST\".\nDeprecated in favor of reference"
+        },
+        "ingress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Volume.File"
+          },
+          "description": "Ingress specifies data that should be fetched and made available within\nthe volume."
+        },
+        "egress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Volume.File"
+          },
+          "description": "Egress specifies data that exists within the volume that should be\nexported to another storage location."
+        },
+        "path": {
+          "type": "string",
+          "title": "Path is specified for host volume types with the absolute path to the\ndirectory to mount.\nDeprecated: will be removed"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Volume reference this volume is referring to."
+        }
+      },
+      "description": "Volume is an instance of a data volume used within the scope of a workflow.\nThere are a couple different types of volumes that have different data\nretention behavior. Volumes are the means of managing data for compute\napplications to process over the course of a workflow and orchestrate\ndata movement to bring injest data into the bounds of a workflow for\ncomputation or export data generated from computation it to other storage\nlocations.\n\nTODO(cedric): deprecate type/path fields\n reserved 2, 5;\n reserved \"type\", \"path\";"
+    },
+    "fuzzball.api.v3.WorkflowDefinition.Volume.File": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.URI",
+          "description": "Source is the origin of the data. The type of URIs supported are\ndetermined by whether this is specified under ingress or egress."
+        },
+        "destination": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.URI",
+          "description": "Destination is the location to move the data. The type of URIs\nsupported are determined by whether this is specified under ingress or\negress."
+        },
+        "policy": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowDefinition.Policy",
+          "description": "policy contains configurable rules that define high level execution\nbehavior of a data transfer such as max execution time and retries on\nfailure."
+        }
+      },
+      "description": "File specifies details of workflow volume data movement."
+    },
+    "fuzzball.api.v3.WorkflowGatewayAttachRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "stdin": {
+          "type": "boolean"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "ws": {
+          "$ref": "#/definitions/fuzzball.api.v3.TerminalSize"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowGatewayAttachResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowGatewayExecRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ws": {
+          "$ref": "#/definitions/fuzzball.api.v3.TerminalSize"
+        },
+        "input": {
+          "type": "string",
+          "format": "byte"
+        },
+        "terminal": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the container to execute the command in."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rank of the container to execute the command in."
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowGatewayExecResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        },
+        "error": {
+          "type": "string",
+          "format": "byte"
+        },
+        "exitCode": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowGatewayLogCommand": {
+      "type": "string",
+      "enum": [
+        "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+      ],
+      "default": "WORKFLOW_GATEWAY_LOG_COMMAND_UNSPECIFIED"
+    },
+    "fuzzball.api.v3.WorkflowGatewayLogResponse": {
+      "type": "object",
+      "properties": {
+        "output": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowGatewayLogShow": {
+      "type": "object",
+      "properties": {
+        "tail": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "follow": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowIDResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowPlan": {
+      "type": "object",
+      "properties": {
+        "stages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowStage"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowSecret": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/fuzzball.api.v3.ValueSecret"
+        },
+        "s3": {
+          "$ref": "#/definitions/fuzzball.api.v3.S3Secret"
+        },
+        "http": {
+          "$ref": "#/definitions/fuzzball.api.v3.HTTPSecret"
+        },
+        "image": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageSecret"
+        },
+        "decryption": {
+          "$ref": "#/definitions/fuzzball.api.v3.ImageDecryptionSecret"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowSecretsMap": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.api.v3.WorkflowSecret"
+          }
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowService.AddWorkflowOwnerBody": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowStage": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/fuzzball.api.v3.WorkflowStatus"
+        },
+        "kind": {
+          "$ref": "#/definitions/fuzzball.api.v3.StageKind"
+        },
+        "error": {
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "details": {
+          "type": "object"
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "fuzzball.api.v3.WorkflowStatus": {
+      "type": "string",
+      "enum": [
+        "STAGE_STATUS_UNSPECIFIED",
+        "STAGE_STATUS_STARTED",
+        "STAGE_STATUS_FINISHED",
+        "STAGE_STATUS_FAILED",
+        "STAGE_STATUS_CANCELED"
+      ],
+      "default": "STAGE_STATUS_UNSPECIFIED",
+      "title": "- STAGE_STATUS_UNSPECIFIED: also used for pending"
+    },
+    "fuzzball.substrate.api.devplugin.v1.Device": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Device ID."
+        },
+        "numa-node": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Numa node associated to the device."
+        },
+        "consumable": {
+          "type": "boolean",
+          "title": "The device is consumable ?"
+        },
+        "allocated": {
+          "type": "boolean",
+          "title": "Is the device allocated, only used for fuzzball.substrate.api.substrate.v1.ResourceShowResponse,\nthis field is ignored when set by a plugin returning DeviceInitResponse"
+        }
+      },
+      "description": "Device represents a single device."
+    },
+    "fuzzball.substrate.api.devplugin.v1.DeviceList": {
+      "type": "object",
+      "properties": {
+        "devices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.substrate.api.devplugin.v1.Device"
+          }
+        }
+      },
+      "description": "Devices holds the device list."
+    },
+    "fuzzball.substrate.api.devplugin.v1.Devices": {
+      "type": "object",
+      "properties": {
+        "list": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fuzzball.substrate.api.devplugin.v1.DeviceList"
+          }
+        }
+      },
+      "description": "Devices managed by a plugin."
+    },
+    "fuzzball.substrate.api.substrate.v1.Core": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64",
+          "title": "core identifier"
+        },
+        "hardwareThreads": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of hardware threads of the core (nil for threads)"
+        },
+        "socketPackage": {
+          "type": "integer",
+          "format": "int64",
+          "title": "socket package associated to the core"
+        },
+        "numaNode": {
+          "type": "integer",
+          "format": "int64",
+          "title": "NUMA node associated to the core"
+        },
+        "allocated": {
+          "type": "boolean",
+          "title": "core allocation state"
+        }
+      }
+    },
+    "fuzzball.substrate.api.substrate.v1.CpuAffinity": {
+      "type": "string",
+      "enum": [
+        "CPU_AFFINITY_UNSPECIFIED",
+        "CPU_AFFINITY_NUMA",
+        "CPU_AFFINITY_SOCKET",
+        "CPU_AFFINITY_CORE"
+      ],
+      "default": "CPU_AFFINITY_UNSPECIFIED"
+    },
+    "fuzzball.substrate.api.substrate.v1.CpuResource": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.CpuAffinity"
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "threads": {
+          "type": "boolean"
+        },
+        "sockets": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "fuzzball.substrate.api.substrate.v1.MemResource": {
+      "type": "object",
+      "properties": {
+        "bytes": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "byCore": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.substrate.api.substrate.v1.NodeResource": {
+      "type": "object",
+      "properties": {
+        "cores": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.Core"
+          },
+          "title": "list of CPU cores on a system"
+        },
+        "freeCores": {
+          "type": "integer",
+          "format": "int64",
+          "title": "number of free CPU cores (hardware threads are not accounted)"
+        },
+        "memoryTotalBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "total memory available on a system"
+        },
+        "memoryFreeBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "free memory available on a system"
+        },
+        "memoryBytesByCore": {
+          "type": "string",
+          "format": "uint64",
+          "title": "rough estimation of the amount of memory available by CPU core"
+        },
+        "threads": {
+          "type": "boolean",
+          "title": "hardware threads support"
+        },
+        "numaNodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.NumaNode"
+          },
+          "title": "NUMA nodes available on a system"
+        },
+        "sockets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.Socket"
+          },
+          "title": "sockets available on a system"
+        },
+        "cpuModelName": {
+          "type": "string",
+          "title": "CPU model name from /proc/cpuinfo"
+        }
+      }
+    },
+    "fuzzball.substrate.api.substrate.v1.NumaNode": {
+      "type": "object",
+      "properties": {
+        "cores": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of CPU cores associated to a NUMA node"
+        },
+        "freeCores": {
+          "type": "integer",
+          "format": "int64",
+          "title": "number of free CPU cores (hardware threads are not accounted)"
+        },
+        "memoryTotalBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "total memory available on a NUMA node"
+        },
+        "memoryFreeBytes": {
+          "type": "string",
+          "format": "uint64",
+          "title": "free memory available on a NUMA node"
+        },
+        "memoryBytesByCore": {
+          "type": "string",
+          "format": "uint64",
+          "title": "rough estimation of the amount of memory available by CPU core"
+        }
+      }
+    },
+    "fuzzball.substrate.api.substrate.v1.Resource": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.CpuResource"
+        },
+        "mem": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.MemResource"
+        },
+        "devices": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "exclusive": {
+          "type": "boolean"
+        }
+      }
+    },
+    "fuzzball.substrate.api.substrate.v1.ResourceShowResponse": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.Resource",
+          "description": "total is the total available resource on the compute service."
+        },
+        "free": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.Resource",
+          "description": "free is the currently free resource on the compute service."
+        },
+        "node": {
+          "$ref": "#/definitions/fuzzball.substrate.api.substrate.v1.NodeResource",
+          "description": "node is the detailed node information of the compute service."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations is the list of annotations associated with the node."
+        },
+        "pluginDevices": {
+          "$ref": "#/definitions/fuzzball.substrate.api.devplugin.v1.Devices",
+          "description": "Plugin devices details."
+        }
+      }
+    },
+    "fuzzball.substrate.api.substrate.v1.Socket": {
+      "type": "object",
+      "properties": {
+        "cores": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of CPU cores associated to a socket"
+        },
+        "freeCores": {
+          "type": "integer",
+          "format": "int64",
+          "title": "number of free CPU cores (hardware threads are not accounted)"
+        },
+        "numaNodes": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": "list of NUMA nodes associated to a socket"
+        }
+      }
+    },
+    "google.protobuf.Any": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "google.protobuf.NullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    },
+    "google.rpc.Status": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
+        }
+      }
+    }
+  }
+}

--- a/nf-fuzzball-submit/README.md
+++ b/nf-fuzzball-submit/README.md
@@ -128,6 +128,8 @@ General options
 
 | Argument               | Default                     | Description                                                         |
 |------------------------|-----------------------------|---------------------------------------------------------------------|
+| `-h`, `--help`         | n/a                         | show this help message and exit                                     |
+| `--version`            | n/a                         | show program's version number and exit                              |
 | `-v`, `--verbose`      | False                       | Enable verbose logging                                              |
 | `-n`, `--dry-run`      | False                       | Print the workflow without submitting                               |
 | `--job-name`           | (UUID from command)         | Name of the Fuzzball workflow                                       |

--- a/nf-fuzzball-submit/README.md
+++ b/nf-fuzzball-submit/README.md
@@ -18,7 +18,7 @@ Installation as a tool (see the [uv tool documentation](https://docs.astral.sh/u
 # from the main branch
 uv tool install "git+https://github.com/ctrliq/nf-fuzzball.git@main#subdirectory=nf-fuzzball-submit"
 # from a release
-uv tool install "git+https://github.com/ctrliq/nf-fuzzball.git@v0.2.0#subdirectory=nf-fuzzball-submit"
+uv tool install "git+https://github.com/ctrliq/nf-fuzzball.git@v0.3.0#subdirectory=nf-fuzzball-submit"
 
 nf-fuzzball-submit --help
 ```
@@ -180,12 +180,12 @@ CLI flags or their corresponding environment variables.
 
 Options for development:
 
-| Argument                | Default         | Description                                             |
-|-------------------------|-----------------|---------------------------------------------------------|
-| `--nf-fuzzball-version` | `0.2.0`         | nf-fuzzball plugin version                              |
-| `--plugin-base-uri`     | GitHub releases | Base URI for the nf-fuzzball plugin                     |
-| `--s3-secret`           | (none)          | Fuzzball S3 secret for plugin download if using S3 URI  |
-| `--fb-version`          | (auto-detected) | Override the Fuzzball API version (e.g., `v3.2`)        |
+| Argument                | Default                   | Description                                            |
+|-------------------------|---------------------------|--------------------------------------------------------|
+| `--nf-fuzzball-version` | same as submission script | nf-fuzzball plugin version                             |
+| `--plugin-base-uri`     | GitHub releases           | Base URI for the nf-fuzzball plugin                    |
+| `--s3-secret`           | (none)                    | Fuzzball S3 secret for plugin download if using S3 URI |
+| `--fb-version`          | (auto-detected)           | Override the Fuzzball API version (e.g., `v3.2`)       |
 
 ## Development
 

--- a/nf-fuzzball-submit/pyproject.toml
+++ b/nf-fuzzball-submit/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-fuzzball-submit"
-version = "0.2.0"
+version = "0.3.0"
 description = "Submit Nextflow pipelines to Fuzzball clusters"
 authors = [{name = "CIQ", email = "info@ciq.com"}]
 license = {text = "Apache-2.0"}

--- a/nf-fuzzball-submit/src/nf_fuzzball_submit/__init__.py
+++ b/nf-fuzzball-submit/src/nf_fuzzball_submit/__init__.py
@@ -1,7 +1,5 @@
 """nf-fuzzball-submit: Submit Nextflow pipelines to Fuzzball clusters."""
 
-__version__ = "0.2.0"
-
 from .auth import ConfigFileAuthenticator, DirectLoginAuthenticator, FuzzballAuthenticator
 from .client import (
     FuzzballClient,

--- a/nf-fuzzball-submit/src/nf_fuzzball_submit/cli.py
+++ b/nf-fuzzball-submit/src/nf_fuzzball_submit/cli.py
@@ -7,6 +7,7 @@ import posixpath
 import re
 import textwrap
 from collections.abc import Callable
+from importlib.metadata import version
 from urllib.parse import urlparse
 
 from .client import DATA_MOUNT
@@ -318,6 +319,7 @@ Notes:
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {version('nf-fuzzball-submit')}")
     auth_group = parser.add_argument_group("Fuzzball config based authentication")
     auth_group.add_argument(
         "-c",
@@ -433,7 +435,7 @@ Notes:
     dev_group.add_argument(
         "--nf-fuzzball-version",
         type=valid_version(prefix="", parts=3),
-        default="0.2.0",
+        default=version("nf-fuzzball-submit"),
         help="nf-fuzzball plugin version.",
     )
 

--- a/nf-fuzzball-submit/tests/test_cli.py
+++ b/nf-fuzzball-submit/tests/test_cli.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import pathlib
+from importlib.metadata import version
 from unittest.mock import patch
 
 import pytest
@@ -68,7 +69,7 @@ class TestCliParsing:
             args = parse_cli()
 
         assert args.nextflow_work_base == "/data/nextflow/executions"
-        assert args.nf_fuzzball_version == "0.2.0"
+        assert args.nf_fuzzball_version == version("nf-fuzzball-submit")
         assert args.nextflow_version == "25.05.0-edge"
         assert args.timelimit == "8h"
         assert args.scratch_volume == "volume://user/ephemeral"

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballExecutor.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballExecutor.groovy
@@ -23,7 +23,11 @@ import com.ciq.fuzzball.api.ApiConfig
 import com.ciq.fuzzball.api.ApiUtils
 import com.ciq.fuzzball.api.WorkflowServiceApi
 import com.ciq.fuzzball.api.StorageClassServiceApi
-import com.ciq.fuzzball.model.*
+import com.ciq.fuzzball.model.FuzzballApiV3Workflow as Workflow
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinition as WorkflowDefinition
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionJobMount as WorkflowDefinitionJobMount
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionVolume as Volume
+import com.ciq.fuzzball.model.FuzzballApiV3ListStorageClassesResponse as ListStorageClassesResponse
 
 // TODO: task batching possibly with TaskArrayExecutor
 

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballPluginConfig.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballPluginConfig.groovy
@@ -5,7 +5,7 @@ import nextflow.config.schema.ConfigScope
 import nextflow.config.schema.ScopeName
 import nextflow.script.dsl.Description
 
-import com.ciq.fuzzball.model.Volume
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionVolume as Volume
 
 @ScopeName('fuzzball')
 @Description('''

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballTaskHandler.groovy
@@ -16,7 +16,12 @@ import nextflow.exception.ProcessException
 import java.nio.file.Path
 
 import com.ciq.fuzzball.api.WorkflowServiceApi
-import com.ciq.fuzzball.model.*
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionJob as WorkflowDefinitionJob
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinition as WorkflowDefinition
+import com.ciq.fuzzball.model.FuzzballApiV3StartWorkflowRequest as StartWorkflowRequest
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowIDResponse as WorkflowIDResponse
+import com.ciq.fuzzball.model.FuzzballApiV3GetWorkflowStatusResponse as GetWorkflowStatusResponse
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowStatus as WorkflowStatus
 
 @Slf4j
 @CompileStatic

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballWorkflowDefinitionJobFactory.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballWorkflowDefinitionJobFactory.groovy
@@ -4,13 +4,13 @@ package com.ciq.fuzzball
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
-import com.ciq.fuzzball.model.Policy
-import com.ciq.fuzzball.model.Timeout
-import com.ciq.fuzzball.model.URI
-import com.ciq.fuzzball.model.WorkflowDefinitionJob
-import com.ciq.fuzzball.model.WorkflowDefinitionJobResource
-import com.ciq.fuzzball.model.WorkflowDefinitionJobResourceCpu
-import com.ciq.fuzzball.model.WorkflowDefinitionJobResourceMemory
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionPolicy as Policy
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionPolicyTimeout as Timeout
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionURI as URI
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionJob as WorkflowDefinitionJob
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionJobResource as WorkflowDefinitionJobResource
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionJobResourceCpu as WorkflowDefinitionJobResourceCpu
+import com.ciq.fuzzball.model.FuzzballApiV3WorkflowDefinitionJobResourceMemory as WorkflowDefinitionJobResourceMemory
 
 import nextflow.processor.TaskRun
 import nextflow.executor.BashWrapperBuilder


### PR DESCRIPTION
- Changes groovy imports to handle new organization of OpenAPI schema resulting in name changes in the generated SDK. Vendors new 3.3 schema.
- Since this makes it hard to maintain compatibility with fuzzball version 3.0-3.2 i am targetting a new nf-fuzzball release with this (0.3.0). The previous release (0.2.0) has essentially the same functionality but uses the imports compatible with earlier Fuzzball API versions. Adjusted versions in the config files to match this new target.
- Future fixes/changes applied to 0.3.x will be backported to 0.2.0
- Added `--version` flag to nf-fuzzball-submit and removed `__version__` from `__init__.py`. THe only places that require manual edits now are build.gradle and pyproject.toml