### PR TITLE
FUZZ-6638: update nextflow version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 plugins {
     // https://plugins.gradle.org/plugin/io.nextflow.nextflow-plugin
     // https://github.com/nextflow-io/nextflow-plugin-gradle
-    id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.6'
+    id("io.nextflow.nextflow-plugin") version "1.0.0-beta.14"
 }
 
 dependencies {
@@ -25,7 +25,7 @@ version = '0.3.0'
 
 nextflowPlugin {
     // minimum nextflow version
-    nextflowVersion = '25.04.0'
+    nextflowVersion = '25.10.4'
 
     provider = 'CIQ'
     description = 'Fuzzball executor'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/nf-fuzzball-submit/src/nf_fuzzball_submit/cli.py
+++ b/nf-fuzzball-submit/src/nf_fuzzball_submit/cli.py
@@ -462,7 +462,7 @@ Notes:
     parser.add_argument(
         "--nextflow-version",
         type=str,
-        default="25.05.0-edge",
+        default="25.10.4",
         help="Nextflow version.",
     )
     parser.add_argument(

--- a/nf-fuzzball-submit/src/nf_fuzzball_submit/client.py
+++ b/nf-fuzzball-submit/src/nf_fuzzball_submit/client.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 # Constants
 DATA_MOUNT = "/data"
 SCRATCH_MOUNT = "/scratch"
+MIN_FUZZBALL_VERSION = (3, 3)
 
 
 class FuzzballClient:
@@ -83,7 +84,8 @@ class FuzzballClient:
         """Validate connection to Fuzzball API and get version.
 
         Raises:
-            ValueError: If connection fails or version cannot be retrieved.
+            ValueError: If connection fails, version cannot be retrieved, or minimum
+                        version is not satisfied.
         """
         try:
             response = self._request("GET", "/version")
@@ -95,6 +97,11 @@ class FuzzballClient:
             raise ValueError("Unexpected error occurred") from e
         else:
             logger.info(f"Connected to Fuzzball {detected_version} API server")
+
+        version_tuple = tuple(int(x.lstrip("v")) for x in detected_version.split("."))
+        if version_tuple < MIN_FUZZBALL_VERSION:
+            min_str = ".".join(str(x) for x in MIN_FUZZBALL_VERSION)
+            raise ValueError(f"Fuzzball v{min_str} or later is required, got {detected_version}")
 
         if self._fb_version is None:
             self._fb_version = detected_version

--- a/nf-fuzzball-submit/src/nf_fuzzball_submit/client.py
+++ b/nf-fuzzball-submit/src/nf_fuzzball_submit/client.py
@@ -423,7 +423,7 @@ class FuzzballClient:
                             "env": env + ([f"FB_CA_CERT={ca_cert_path}"] if self._ca_cert_file is not None else []),
                             "policy": {"timeout": {"execute": args.timelimit}},
                             "resource": {"cpu": {"cores": args.cores}, "memory": {"size": args.memory}},
-                            "requires": ["setup"],
+                            "depends-on": [{"name": "setup", "status": "FINISHED"}],
                         },
                     },
                 },
@@ -447,7 +447,7 @@ class FuzzballClient:
                     ],
                     "policy": {"timeout": {"execute": args.egress_timelimit}},
                     "resource": {"cpu": {"cores": 1}, "memory": {"size": "1GB"}},
-                    "requires": ["nextflow"],
+                    "depends-on": [{"name": "nextflow", "status": "FINISHED"}],
                 }
 
             # add in the local files

--- a/nf-fuzzball-submit/tests/test_cli.py
+++ b/nf-fuzzball-submit/tests/test_cli.py
@@ -70,7 +70,6 @@ class TestCliParsing:
 
         assert args.nextflow_work_base == "/data/nextflow/executions"
         assert args.nf_fuzzball_version == version("nf-fuzzball-submit")
-        assert args.nextflow_version == "25.05.0-edge"
         assert args.timelimit == "8h"
         assert args.scratch_volume == "volume://user/ephemeral"
         assert args.data_volume == "volume://user/persistent"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,7 @@
 plugins {
     // see https://github.com/gradle/foojay-toolchains
     // see https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = 'nf-fuzzball'
-include('plugins')
-include('plugins:nf-fuzzball')

--- a/src/main/groovy/com/ciq/fuzzball/FuzzballExecutor.groovy
+++ b/src/main/groovy/com/ciq/fuzzball/FuzzballExecutor.groovy
@@ -147,7 +147,7 @@ class FuzzballExecutor extends Executor implements ExtensionPoint {
      */
     @Override
     protected TaskMonitor createTaskMonitor() {
-        return TaskPollingMonitor.create(session, name, 20, Duration.of('20 sec'))
+        return TaskPollingMonitor.create(session, config, name, 20, Duration.of('20 sec'))
     }
 
     /**


### PR DESCRIPTION
This PR bundles a small number of changes that won't be backported to 0.2.0:
- updated nextflow to 25.10.4 (though this can be backported if needed)
- updated gradle to the latest 8.x (8.14.4) and made some small changes to settings.gradle that were using deprecated gradle features
- updated the nextflow gradle plugin to 1.0.0-beta.14
- migrated the submission script to `depends-on` from the deprecated `requires`. This is not compatible with Fuzzball 3.2 so this upcoming nf-fuzzball release which requires Fuzzball >=3.3 seems like the right place to introduce this change.