### PR TITLE
chore(ci): bump GitHub Actions off Node 20 runtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
       - name: Determine which schemas to build
@@ -112,7 +112,7 @@ jobs:
       matrix: ${{fromJson(needs.determine-matrix.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           submodules: true
@@ -140,7 +140,7 @@ jobs:
       matrix: ${{fromJson(needs.determine-matrix.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           submodules: true


### PR DESCRIPTION
## Summary

Node 20 reached EOL on 2026-04-30. This PR bumps GitHub Actions to current stable releases, pinned by full commit SHA with the target tag in a trailing comment.


## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v6.0.2` |

Files touched: **1** workflow file(s), **3** line change(s).

## Test plan

- [ ] Existing CI runs on this PR and stays green.
- [ ] If this repo's workflows aren't PR-triggered, dispatch them manually after merge or via `workflow_dispatch`.

---

Part of an org-wide bulk update across ~135 ctrliq repos to escape Node 20 EOL.
