### PR TITLE
Pin GitHub Actions to SHAs [SRE-1802]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           fuzzball_version: ${{ matrix.fuzzball_version }}
       - name: Setup Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 21
           architecture: x64
@@ -166,7 +166,7 @@ jobs:
             echo "Plugin version in build.gradle matches tag"
           fi
       - name: Setup Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 21
           architecture: x64
@@ -181,7 +181,7 @@ jobs:
           echo "ARTIFACT_NAME=${aname}" >> "$GITHUB_ENV"
       - name: Create or update release and attach artifact
         if: github.ref_type == 'tag' && (github.event_name == 'push' || github.event.inputs.publish_release == 'true')
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           name: Release ${{ env.PLUGIN_VERSION }}
           tag: ${{ env.PLUGIN_VERSION }}


### PR DESCRIPTION
## Summary
Pin GitHub Actions references in this repo to immutable commit SHAs (with the original tag/branch preserved in a trailing comment).

## Scope
This PR pins:
- Internal `ctrliq/*` reusable workflow and action references
- External actions

## Files touched

- `.github/workflows/build.yml`

## Test plan
- [ ] Workflow runs succeed on this branch (or on next trigger after merge)
- [ ] Once this and any companion clo-ciq PR merge, this repo has zero unpinned external/internal refs and `sha_pinning_required` can be enabled on it
